### PR TITLE
move check for the context to execute method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 dist/
 bin/
+
+.speechly.yaml

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -70,14 +70,13 @@ func initConfig() {
 			break
 		}
 	}
-	if sc == (SpeechlyContext{}) {
-		log.Fatalf("Could not resolve selected context: %s", conf.CurrentContext)
-	}
 }
 
 func Execute() error {
-
 	//cs := viper.UnmarshalKey("contexts", &sc)
+	if sc == (SpeechlyContext{}) {
+		return rootCmd.ExecuteContext(nil)
+	}
 
 	md := metadata.Pairs("authorization", fmt.Sprintf("Bearer %s", sc.Apikey))
 	ctx := metadata.NewOutgoingContext(context.Background(), md)


### PR DESCRIPTION
This makes it possible to add a config, but the check `sc == (SpeechlyContext{})` is not run before other commands and they might thus fail in ugly ways..