### PR TITLE
Add a command for creating apps

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -1,0 +1,90 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/spf13/cobra"
+
+	configv1 "github.com/speechly/cli/gen/go/speechly/config/v1"
+)
+
+var validLangs = []string{"en-US", "fi-FI"}
+
+var createCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a new application in the current context (project)",
+	Run: func(cmd *cobra.Command, args []string) {
+		name, err := cmd.Flags().GetString("name")
+		if err != nil {
+			log.Fatalf("Missing name: %s", err)
+		}
+
+		lang, err := cmd.Flags().GetString("language")
+		if err != nil {
+			log.Fatalf("Missing language: %s", err)
+		}
+
+		if err := validateLang(lang); err != nil {
+			log.Fatalf("Invalid language: %s", err)
+		}
+
+		ctx := cmd.Context()
+
+		projects, err := config_client.GetProject(ctx, &configv1.GetProjectRequest{})
+		if err != nil {
+			log.Fatalf("Error fetching projects: %s", err)
+		}
+
+		if len(projects.GetProject()) < 1 {
+			log.Fatal("Error fetching projects: no projects exist for the given token")
+		}
+
+		pid := projects.GetProject()[0]
+		a := &configv1.App{
+			Language: lang,
+			Name:     name,
+		}
+		req := &configv1.CreateAppRequest{
+			Project: pid,
+			App:     a,
+		}
+
+		res, err := config_client.CreateApp(ctx, req)
+		if err != nil {
+			log.Fatalf("Error creating an app: %s", err)
+		}
+
+		// Cannot use the response here, because it only contains the id.
+		a.Id = res.GetApp().GetId()
+
+		cmd.Printf("Created an application in project %s:\n\n", pid)
+		if err := printApps(cmd.OutOrStdout(), a); err != nil {
+			log.Fatalf("Error listing app: %s", err)
+		}
+	},
+}
+
+func init() {
+	createCmd.Flags().StringP("language", "l", "", "application language (current only 'en-US' and 'fi-FI' are supported)")
+	if err := createCmd.MarkFlagRequired("language"); err != nil {
+		log.Fatalf("Internal error: %s", err)
+	}
+
+	createCmd.Flags().StringP("name", "n", "", "application name")
+	if err := createCmd.MarkFlagRequired("name"); err != nil {
+		log.Fatalf("Internal error: %s", err)
+	}
+
+	rootCmd.AddCommand(createCmd)
+}
+
+func validateLang(l string) error {
+	for _, v := range validLangs {
+		if v == l {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("unsupported language: %s", l)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -71,10 +71,9 @@ func initConfig() {
 	viper.AutomaticEnv()
 
 	if err := viper.ReadInConfig(); err != nil {
-		if os.Args[1] != "config" {
-			log.Println("Please create a configuration file first:")
-			log.Println("")
-			log.Println("\tspeechly config add --apikey APIKEY")
+		if len(os.Args) < 2 || os.Args[1] != "config" {
+			log.Print("Please create a configuration file first:\n\n")
+			log.Printf("%s config add --apikey APIKEY --name NAME", os.Args[0])
 			log.Println("")
 			os.Exit(1)
 		}


### PR DESCRIPTION
### What

This PR implements a new command that can be used for creating new apps. The app created is not deployed, so currently if one wants to create & deploy, it will still require two commands to be issued.

### Why

Currently the only other way to create a new app is to do so through the web UI, which is jarring in terms of the workflow. Additionally, the idea is to have the CLI tool on par (or almost) with the web UI in terms of functionality.

Here's an example output:
```sh
$ speechly-config list
List of applications in project REDACTED

APP ID      STATUS            NAME
REDACTED    STATUS_TRAINED    Test App

$ speechly-config create -n "cli-test" -l "en-US"
Created an application in project REDACTED:

APP ID      STATUS                NAME
REDACTED    STATUS_UNSPECIFIED    cli-test

$ speechly-config list
List of applications in project REDACTED

APP ID      STATUS                NAME
REDACTED    STATUS_TRAINED        Test App
REDACTED    STATUS_UNSPECIFIED    cli-test
```

This PR also fixes a corner-case panic for when the app is invoked without a config and without a command, plus it switches to tabwriter for printing the apps to STDOUT.