### PR TITLE
Add a command for deleting apps

### DIFF
--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -1,0 +1,84 @@
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"log"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	configv1 "github.com/speechly/cli/gen/go/speechly/config/v1"
+)
+
+var deleteCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "Delete an existing application",
+	Run: func(cmd *cobra.Command, args []string) {
+		force, err := cmd.Flags().GetBool("force")
+		if err != nil {
+			log.Fatalf("Missing force flag: %s", err)
+		}
+
+		dry, err := cmd.Flags().GetBool("dry-run")
+		if err != nil {
+			log.Fatalf("Missing dry-run flag: %s", err)
+		}
+
+		id, err := cmd.Flags().GetString("app")
+		if err != nil {
+			log.Fatalf("Missing app ID: %s", err)
+		}
+
+		if !force && !confirm(fmt.Sprintf("Deleting app %s, are you sure?", id), cmd.OutOrStdout(), cmd.InOrStdin()) {
+			cmd.Println("Deletion aborted.")
+			return
+		}
+
+		if !dry {
+			if _, err := config_client.DeleteApp(
+				cmd.Context(),
+				&configv1.DeleteAppRequest{
+					AppId: id,
+				},
+			); err != nil {
+				log.Fatalf("Error deleting the app: %s", err)
+			}
+		}
+
+		cmd.Printf("Successfully deleted app %s.\n", id)
+	},
+}
+
+func init() {
+	deleteCmd.Flags().StringP("app", "a", "", "application ID to delete")
+	if err := deleteCmd.MarkFlagRequired("app"); err != nil {
+		log.Fatalf("Internal error: %s", err)
+	}
+
+	deleteCmd.Flags().BoolP("force", "f", false, "skip confirmation prompt")
+	deleteCmd.Flags().BoolP("dry-run", "d", false, "don't perform the deletion")
+
+	rootCmd.AddCommand(deleteCmd)
+}
+
+func confirm(prompt string, dst io.Writer, src io.Reader) bool {
+	read := bufio.NewReader(src)
+
+	for {
+		fmt.Fprintf(dst, "%s [y/n]: ", prompt)
+
+		r, err := read.ReadString('\n')
+		if err != nil {
+			return false
+		}
+
+		r = strings.ToLower(strings.TrimSpace(r))
+		if r == "y" || r == "yes" {
+			return true
+		} else if r == "n" || r == "no" {
+			return false
+		}
+	}
+}


### PR DESCRIPTION
### What

This PR implements a new command that can be used for deleting existing apps. There's a confirmation prompt and a couple of flags to modify the behaviour of command - one for skipping the prompt and another for a dry run.

### Why

Currently the only other way for deleting apps is to do so through the web UI, which is jarring in terms of the workflow. Additionally, the idea is to have the CLI tool on par (or almost) with the web UI in terms of functionality.

Here's an example output:

```sh
$ speechly-config delete
Error: required flag(s) "app" not set
Usage:
  speechly delete [flags]

Flags:
  -a, --app string   application ID to delete
  -d, --dry-run      don't perform the deletion
  -f, --force        skip confirmation prompt
  -h, --help         help for delete


$ speechly-config list
List of applications in project REDACTED:

APP ID					STATUS		NAME
55fcf1eb-a43c-4b88-b40b-b042288a1edc	STATUS_TRAINED	Test App

$ speechly-config delete -a 55fcf1eb-a43c-4b88-b40b-b042288a1edc
Deleting app 55fcf1eb-a43c-4b88-b40b-b042288a1edc, are you sure? [y/n]: y
Successfully deleted app 55fcf1eb-a43c-4b88-b40b-b042288a1edc.

$ speechly-config list
List of applications in project REDACTED:

No applications found.
```