### PR TITLE
Compile command

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	salv1 "github.com/speechly/api/go/speechly/sal/v1"
+)
+
+type ValidateWriter struct {
+	appId  string
+	stream salv1.Compiler_ValidateClient
+}
+
+type CompileWriter struct {
+	appId  string
+	stream salv1.Compiler_CompileClient
+}
+
+func createAppsource(appId string, data []byte) *salv1.AppSource {
+	contentType := salv1.AppSource_CONTENT_TYPE_TAR
+	return &salv1.AppSource{AppId: appId, DataChunk: data, ContentType: contentType}
+}
+
+func (u ValidateWriter) Write(data []byte) (n int, err error) {
+	if err = u.stream.Send(createAppsource(u.appId, data)); err != nil {
+		return 0, err
+	}
+	return len(data), nil
+}
+
+func (u CompileWriter) Write(data []byte) (n int, err error) {
+	if err = u.stream.Send(createAppsource(u.appId, data)); err != nil {
+		return 0, err
+	}
+	return len(data), nil
+}

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -2,12 +2,8 @@ package cmd
 
 import (
 	"log"
-	"os"
-	"path/filepath"
 
 	"github.com/spf13/cobra"
-
-	salv1 "github.com/speechly/api/go/speechly/sal/v1"
 )
 
 var validateCmd = &cobra.Command{
@@ -21,15 +17,7 @@ API and validated. Possible errors are printed to stdout.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := cmd.Context()
 		appId, _ := cmd.Flags().GetString("app")
-		inDir := args[0]
-		absPath, _ := filepath.Abs(inDir)
-		log.Printf("Project dir: %s\n", absPath)
-		// create a tar package from files in memory
-		uploadData := createTarFromDir(inDir)
-
-		if len(uploadData.files) == 0 {
-			log.Fatalf("No files found for validation!\n\nPlease ensure the files are named *.yaml or *.csv")
-		}
+		uploadData := createAndValidateTar(args[0])
 
 		// open a stream for upload
 		stream, err := compile_client.Validate(ctx)
@@ -49,25 +37,7 @@ API and validated. Possible errors are printed to stdout.`,
 			log.Fatalf("Validate failed: %s", err)
 		}
 		if len(validateResult.Messages) > 0 {
-			log.Println("Configuration validation failed")
-			for _, message := range validateResult.Messages {
-				var errorLevel string
-				switch message.Level {
-				case salv1.LineReference_LEVEL_NOTE:
-					errorLevel = "NOTE"
-				case salv1.LineReference_LEVEL_WARNING:
-					errorLevel = "WARNING"
-				case salv1.LineReference_LEVEL_ERROR:
-					errorLevel = "ERROR"
-				}
-				if message.File != "" {
-					log.Printf("%s:%d:%d:%s:%s\n", message.File, message.Line,
-						message.Column, errorLevel, message.Message)
-				} else {
-					log.Printf("%s: %s", errorLevel, message.Message)
-				}
-			}
-			os.Exit(1)
+			printLineErrors(validateResult.Messages)
 		} else {
 			log.Println("Configuration OK.")
 		}


### PR DESCRIPTION
The compile command outputs 32 compiled SAL examples, line by line.

Later, the 32 could be only default value and user could change it, between some range.