### PR TITLE
Fix/training time

### DIFF
--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -12,12 +12,12 @@ import (
 )
 
 func formatSeconds(seconds int32) string {
-    m := seconds / 60
-    s := seconds % 60
-    if m == 0 {
-	return fmt.Sprintf("%02ds", s)
-    }
-    return fmt.Sprintf("%02dm%02ds", m, s)
+	m := seconds / 60
+	s := seconds % 60
+	if m == 0 {
+		return fmt.Sprintf("%02ds", s)
+	}
+	return fmt.Sprintf("%02dm%02ds", m, s)
 }
 
 var describeCmd = &cobra.Command{

--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -11,6 +11,15 @@ import (
 	configv1 "github.com/speechly/api/go/speechly/config/v1"
 )
 
+func formatSeconds(seconds int32) string {
+    m := seconds / 60
+    s := seconds % 60
+    if m == 0 {
+	return fmt.Sprintf("%02ds", s)
+    }
+    return fmt.Sprintf("%02dm%02ds", m, s)
+}
+
 var describeCmd = &cobra.Command{
 	Use:   "describe",
 	Short: "Print details about an application",
@@ -31,11 +40,13 @@ var describeCmd = &cobra.Command{
 		if app.App.Status == configv1.App_STATUS_FAILED {
 			cmd.Printf("Status:\t%s\n", app.App.ErrorMsg)
 		} else if app.App.Status == configv1.App_STATUS_TRAINING {
-			cmd.Printf("Status:\t%s estimated time remaining: ", app.App.Status)
-			if app.App.EstimatedRemainingSec > 0 {
-				cmd.Printf("%d seconds\n", app.App.EstimatedRemainingSec)
-			} else {
-				cmd.Printf("unknown\n")
+			if app.App.TrainingTimeSec > 0 {
+				age := formatSeconds(app.App.TrainingTimeSec)
+				cmd.Printf("Status:\t%s, age %s", app.App.Status, age)
+				if app.App.EstimatedTrainingTimeSec > 0 {
+					estim := (app.App.EstimatedTrainingTimeSec / 60) + 1
+					cmd.Printf(", estimated about %02dm\n", estim)
+				}
 			}
 
 			// if watch flag given, remain here and fetech app state in loop

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/mitchellh/mapstructure v1.4.1 // indirect
 	github.com/pelletier/go-toml v1.8.1 // indirect
 	github.com/smartystreets/assertions v1.2.0 // indirect
-	github.com/speechly/api/go v0.0.0-20210209064752-cd897dc0fa9e
+	github.com/speechly/api/go v0.0.0-20210223112733-0119732e8124
 	github.com/spf13/afero v1.5.1 // indirect
 	github.com/spf13/cast v1.3.1 // indirect
 	github.com/spf13/cobra v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -224,6 +224,8 @@ github.com/speechly/api/go v0.0.0-20210113134434-35c5ed4e3c69 h1:f68DOphGgk3CstD
 github.com/speechly/api/go v0.0.0-20210113134434-35c5ed4e3c69/go.mod h1:KvNvGseEYbeNswC/9TA8LMQ0vPXGzcuWlY88N3x5V5Y=
 github.com/speechly/api/go v0.0.0-20210209064752-cd897dc0fa9e h1:BlT/MrrU8NcNbonAkXiMs80p3fZTk82XsnH+PptD6Ms=
 github.com/speechly/api/go v0.0.0-20210209064752-cd897dc0fa9e/go.mod h1:KvNvGseEYbeNswC/9TA8LMQ0vPXGzcuWlY88N3x5V5Y=
+github.com/speechly/api/go v0.0.0-20210223112733-0119732e8124 h1:L8XqegHOGSm3DOvdpXcqt6ztWuUSJYn5MD7MHfjXqio=
+github.com/speechly/api/go v0.0.0-20210223112733-0119732e8124/go.mod h1:KvNvGseEYbeNswC/9TA8LMQ0vPXGzcuWlY88N3x5V5Y=
 github.com/spf13/afero v1.1.2 h1:m8/z1t7/fwjysjQRYbP0RD+bUIF/8tJwPdEZsI83ACI=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.3.3 h1:p5gZEKLYoL7wh8VrJesMaYeNxdEd1v3cb4irOk9zB54=


### PR DESCRIPTION
Show deploy age and estimate instead of remaining seconds.

Output of the describe command would now look like
```
~ cli % speechly describe -a 01f...07
AppId:	01f...07
Name:	App name here
Lang:	en-US
Status:	STATUS_TRAINING, age 07m09s, estimated about 09m
```