### PR TITLE
Print queue size if the deploy is queued

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -77,7 +77,7 @@ as the active model for the application.`,
 		// if watch flag given, wait for deployment to finish
 		wait, _ := cmd.Flags().GetBool("watch")
 		if wait {
-			waitForDeploymentFinished(ctx, appId)
+			waitForDeploymentFinished(cmd, appId)
 		}
 	},
 }

--- a/cmd/sample.go
+++ b/cmd/sample.go
@@ -56,7 +56,7 @@ API and compiled. If configuration is valid, a set of examples are printed to st
 				printStats(cmd.OutOrStdout(), compileResult.Templates, simpleStats, advancedStats, int32(limit))
 			} else {
 				for _, message := range compileResult.Templates {
-					fmt.Fprintf(cmd.OutOrStdout(),"%s\n", message)
+					fmt.Fprintf(cmd.OutOrStdout(), "%s\n", message)
 				}
 			}
 		}


### PR DESCRIPTION
If the deploy is queued, show following output for `describe`

```
~ cli % speechly describe -a 60...18
AppId:	60...18
Name:	My Voice App
Lang:	en-US
Status:	STATUS_NEW	Queued (3 jobs before this)
```
Also fix the estimate when deploying with `--watch` flag.