### PR TITLE
CLI improvements

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,6 +17,6 @@ jobs:
       - name: build
         run: make build
       - name: prepare config
-        run: bin/speechly config add --apikey APIKEY --name default
+        run: bin/speechly config add --apikey APIKEY --name default --skip-online-validation
       - name: Test
         run: make test

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ BIN     := speechly
 VERSION ?= latest
 SRC     = $(shell find cmd -type f -name '*.go')
 
+all: build test lint
+
 build: bin/speechly
 
 bin/speechly: $(shell git ls-files)
@@ -19,4 +21,4 @@ lint:
 fmt:
 	gofmt -l -w $(SRC)
 
-.PHONY: build lint clean fmt
+.PHONY: all build lint clean fmt

--- a/cmd/annotate.go
+++ b/cmd/annotate.go
@@ -107,6 +107,10 @@ To evaluate already deployed Speechly app, you need a set of evaluation examples
 		}
 
 		evaluate, err := cmd.Flags().GetBool("evaluate")
+		if err != nil {
+			log.Fatalf("Missing evaluate flag: %s", err)
+		}
+
 		if evaluate && preAnnotated {
 			EvaluateAnnotatedUtterances(wluResponsesToString(res.Responses), annotated)
 			os.Exit(0)
@@ -131,10 +135,10 @@ To evaluate already deployed Speechly app, you need a set of evaluation examples
 }
 
 func removeAnnotations(line string) string {
-	removablePattern := regexp.MustCompile("\\*([^ ]+)(?: |$)|\\(([^)]+)\\)")
+	removablePattern := regexp.MustCompile(`\*([^ ]+)(?: |$)|\(([^)]+)\)`)
 	line = removablePattern.ReplaceAllString(line, "")
 
-	entityValuePattern := regexp.MustCompile("\\[([^]]+)]")
+	entityValuePattern := regexp.MustCompile(`\[([^]]+)]`)
 	return entityValuePattern.ReplaceAllStringFunc(line, func(s string) string {
 		pipeIndex := strings.Index(s, "|")
 		if pipeIndex == -1 {

--- a/cmd/annotate.go
+++ b/cmd/annotate.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bufio"
 	"encoding/csv"
+	"fmt"
 	"io"
 	"log"
 	"os"
@@ -67,13 +68,25 @@ To evaluate already deployed Speechly app, you need a set of evaluation examples
 			log.Fatalf("Missing pre-annotated flag: %s", err)
 		}
 
+		deAnnotate, err := cmd.Flags().GetBool("de-annotate")
+		if err != nil {
+			log.Fatalf("Missing de-annotated flag: %s", err)
+		}
+
 		annotated := data
-		if preAnnotated {
+		if preAnnotated || deAnnotate {
 			transcripts := make([]string, len(data))
 			for i, line := range data {
 				transcripts[i] = removeAnnotations(line)
 			}
 			data = transcripts
+		}
+
+		if deAnnotate {
+			for _, line := range data {
+				fmt.Println(line)
+			}
+			os.Exit(0)
 		}
 
 		wluRequests := make([]*wluv1.WLURequest, len(data))
@@ -168,6 +181,7 @@ func init() {
 	annotateCmd.Flags().StringP("output", "o", "", "where to store annotated utterances, if not provided, print to stdout.")
 	annotateCmd.Flags().StringP("reference-date", "r", "", "reference date in YYYY-MM-DD format, if not provided use current date.")
 	annotateCmd.Flags().BoolP("pre-annotated", "p", false, "the input is in SAL format.")
+	annotateCmd.Flags().BoolP("de-annotate", "d", false, "instead of adding annotation, remove annotations from output. Implies --pre-annotated")
 	annotateCmd.Flags().BoolP("evaluate", "e", false, "print evaluation stats instead of the annotated output. Requires --pre-annotated")
 }
 

--- a/cmd/annotate.go
+++ b/cmd/annotate.go
@@ -63,10 +63,6 @@ To evaluate already deployed Speechly app, you need a set of evaluation examples
 		}
 
 		data := readLines(inputFile)
-		preAnnotated, err := cmd.Flags().GetBool("pre-annotated")
-		if err != nil {
-			log.Fatalf("Missing pre-annotated flag: %s", err)
-		}
 
 		deAnnotate, err := cmd.Flags().GetBool("de-annotate")
 		if err != nil {
@@ -74,13 +70,11 @@ To evaluate already deployed Speechly app, you need a set of evaluation examples
 		}
 
 		annotated := data
-		if preAnnotated || deAnnotate {
-			transcripts := make([]string, len(data))
-			for i, line := range data {
-				transcripts[i] = removeAnnotations(line)
-			}
-			data = transcripts
+		transcripts := make([]string, len(data))
+		for i, line := range data {
+			transcripts[i] = removeAnnotations(line)
 		}
+		data = transcripts
 
 		if deAnnotate {
 			for _, line := range data {
@@ -111,7 +105,7 @@ To evaluate already deployed Speechly app, you need a set of evaluation examples
 			log.Fatalf("Missing evaluate flag: %s", err)
 		}
 
-		if evaluate && preAnnotated {
+		if evaluate {
 			EvaluateAnnotatedUtterances(wluResponsesToString(res.Responses), annotated)
 			os.Exit(0)
 		}
@@ -184,9 +178,8 @@ func init() {
 	annotateCmd.Flags().StringP("input", "i", "", "evaluation utterances, separated by newline, if not provided, read from stdin.")
 	annotateCmd.Flags().StringP("output", "o", "", "where to store annotated utterances, if not provided, print to stdout.")
 	annotateCmd.Flags().StringP("reference-date", "r", "", "reference date in YYYY-MM-DD format, if not provided use current date.")
-	annotateCmd.Flags().BoolP("pre-annotated", "p", false, "the input is in SAL format.")
-	annotateCmd.Flags().BoolP("de-annotate", "d", false, "instead of adding annotation, remove annotations from output. Implies --pre-annotated")
-	annotateCmd.Flags().BoolP("evaluate", "e", false, "print evaluation stats instead of the annotated output. Requires --pre-annotated")
+	annotateCmd.Flags().BoolP("de-annotate", "d", false, "instead of adding annotation, remove annotations from output.")
+	annotateCmd.Flags().BoolP("evaluate", "e", false, "print evaluation stats instead of the annotated output.")
 }
 
 func printEvalResultCSV(out io.Writer, items []*wluv1.WLUResponse) error {

--- a/cmd/annotate.go
+++ b/cmd/annotate.go
@@ -197,7 +197,7 @@ func scanLines(file *os.File) []string {
 
 func init() {
 	rootCmd.AddCommand(annotateCmd)
-	annotateCmd.Flags().StringP("app", "a", "", "app id of the application to evaluate. Can alternatively be given as the last positional argument")
+	annotateCmd.Flags().StringP("app", "a", "", "app id of the application to evaluate. Can alternatively be given as the first positional argument")
 	annotateCmd.Flags().StringP("input", "i", "", "evaluation utterances, separated by newline, if not provided, read from stdin. Can alternatively be given as the first positional argument.")
 	annotateCmd.Flags().StringP("output", "o", "", "where to store annotated utterances, if not provided, print to stdout.")
 	annotateCmd.Flags().StringP("reference-date", "r", "", "reference date in YYYY-MM-DD format, if not provided use current date.")

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"time"
@@ -59,4 +60,15 @@ func waitForAppStatus(cmd *cobra.Command, configClient configv1.ConfigAPIClient,
 		}
 		time.Sleep(10 * time.Second)
 	}
+}
+
+func checkSoleAppArgument(cmd *cobra.Command, args []string) error {
+	appId, err := cmd.Flags().GetString("app")
+	if err != nil {
+		log.Fatalf("Missing app ID: %s", err)
+	}
+	if appId == "" && len(args) < 1 {
+		return fmt.Errorf("app_id must be given with flag --app or as the sole positional argument")
+	}
+	return nil
 }

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -199,6 +199,9 @@ var configUseCmd = &cobra.Command{
 			}
 			name = conf.Contexts[i-1].Name
 		}
+		if err := ensureContextExists(cmd.Context(), name); err != nil {
+			log.Fatalf("Unknown context %s", name)
+		}
 
 		viper.Set("current-context", name)
 		if err := viper.WriteConfig(); err != nil {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -22,13 +22,19 @@ var configCmd = &cobra.Command{
 		cmd.Printf("Settings file used: %s\n", viper.ConfigFileUsed())
 		cmd.Printf("Current project: %s\n", conf.CurrentContext)
 		cmd.Printf("Known projects:\n")
+
 		for _, c := range conf.Contexts {
+			prefix := "- "
+			if c.Name == conf.CurrentContext {
+				prefix = "* "
+			}
+
 			if c.Name == c.RemoteName {
-				cmd.Printf("- %s\n", c.Name)
+				cmd.Printf("%s%s\n", prefix, c.Name)
 			} else if c.RemoteName == "" {
-				cmd.Printf("- %s (name unknown)\n", c.Name)
+				cmd.Printf("%s%s (name unknown)\n", prefix, c.Name)
 			} else {
-				cmd.Printf("- %s (%s)\n", c.Name, c.RemoteName)
+				cmd.Printf("%s%s (%s)\n", prefix, c.Name, c.RemoteName)
 			}
 		}
 	},
@@ -155,17 +161,22 @@ var configUseCmd = &cobra.Command{
 	Use:   "use",
 	Short: "Select the default project used",
 	Run: func(cmd *cobra.Command, args []string) {
+		previousContext := viper.Get("current-context")
 		name, _ := cmd.Flags().GetString("name")
 		if name == "" {
 			conf := clients.GetConfig(cmd.Context())
 			cmd.Printf("Known projects:\n")
 			for ixd, c := range conf.Contexts {
+				prefix := fmt.Sprintf("%d:  ", ixd+1)
+				if c.Name == previousContext {
+					prefix = "*   "
+				}
 				if c.Name == c.RemoteName {
-					cmd.Printf("%d:  %s\n", ixd, c.Name)
+					cmd.Printf("%s%s\n", prefix, c.Name)
 				} else if c.RemoteName == "" {
-					cmd.Printf("%d:  %s (name unknown)\n", ixd, c.Name)
+					cmd.Printf("%s%s (name unknown)\n", prefix, c.Name)
 				} else {
-					cmd.Printf("%d:  %s (%s)\n", ixd, c.Name, c.RemoteName)
+					cmd.Printf("%s%s (%s)\n", prefix, c.Name, c.RemoteName)
 				}
 			}
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -18,7 +18,7 @@ var configCmd = &cobra.Command{
 	Short:   "Manage API access to Speechly projects",
 	Run: func(cmd *cobra.Command, args []string) {
 		conf := clients.GetConfig(cmd.Context())
-		cmd.Printf("Configuration file used: %s\n", viper.ConfigFileUsed())
+		cmd.Printf("Settings file used: %s\n", viper.ConfigFileUsed())
 		cmd.Printf("Current project: %s\n", conf.CurrentContext)
 		cmd.Printf("Known projects:\n")
 		for _, c := range conf.Contexts {
@@ -31,7 +31,7 @@ var validName = regexp.MustCompile(`[^A-Za-z0-9]+`)
 
 var configAddCmd = &cobra.Command{
 	Use:   "add",
-	Short: "Configure access to a pre-existing project",
+	Short: "Add access to a pre-existing project",
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		name, _ := cmd.Flags().GetString("name")
 		if validName.MatchString(name) {
@@ -53,15 +53,15 @@ var configAddCmd = &cobra.Command{
 		viper.Set("contexts", append(conf.Contexts, clients.SpeechlyContext{Host: host, Apikey: apikey, Name: name}))
 		viper.Set("current-context", name)
 		if err := viper.WriteConfig(); err != nil {
-			log.Fatalf("Failed to write the config: %s", err)
+			log.Fatalf("Failed to write settings: %s", err)
 		}
-		cmd.Printf("Wrote configuration to file: %s\n", viper.ConfigFileUsed())
+		cmd.Printf("Wrote settings to file: %s\n", viper.ConfigFileUsed())
 	},
 }
 
 var configRemoveCmd = &cobra.Command{
 	Use:   "remove",
-	Short: "Remove access to a project from configuration",
+	Short: "Remove access to a project",
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		name, _ := cmd.Flags().GetString("name")
 		if err := ensureContextExists(cmd.Context(), name); err != nil {
@@ -83,9 +83,9 @@ var configRemoveCmd = &cobra.Command{
 		}
 		viper.Set("contexts", conf.Contexts)
 		if err := viper.WriteConfig(); err != nil {
-			log.Fatalf("Failed to write the config: %s", err)
+			log.Fatalf("Failed to write settings: %s", err)
 		}
-		cmd.Printf("Wrote configuration to file: %s\n", viper.ConfigFileUsed())
+		cmd.Printf("Wrote settings to file: %s\n", viper.ConfigFileUsed())
 	},
 }
 
@@ -115,9 +115,9 @@ var configUseCmd = &cobra.Command{
 
 		viper.Set("current-context", name)
 		if err := viper.WriteConfig(); err != nil {
-			log.Fatalf("Failed to write the config: %s", err)
+			log.Fatalf("Failed to write settings: %s", err)
 		}
-		cmd.Printf("Wrote configuration to file: %s\n", viper.ConfigFileUsed())
+		cmd.Printf("Wrote settings to file: %s\n", viper.ConfigFileUsed())
 	},
 }
 
@@ -128,7 +128,7 @@ func ensureContextExists(ctx context.Context, name string) error {
 			return nil
 		}
 	}
-	return fmt.Errorf("context named %s not found in configuration", name)
+	return fmt.Errorf("project named %s is not known", name)
 }
 
 func init() {

--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -1,9 +1,9 @@
 package cmd
 
 import (
-	"os"
-	"log"
 	"bytes"
+	"log"
+	"os"
 
 	"github.com/spf13/cobra"
 
@@ -13,9 +13,9 @@ import (
 )
 
 type ConvertWriter struct {
-	stream    salv1.Compiler_ConvertClient
-	format    salv1.ConvertRequest_InputFormat
-	language  string
+	stream   salv1.Compiler_ConvertClient
+	format   salv1.ConvertRequest_InputFormat
+	language string
 }
 
 func (u ConvertWriter) Write(data []byte) (n int, err error) {
@@ -26,13 +26,12 @@ func (u ConvertWriter) Write(data []byte) (n int, err error) {
 	return len(data), nil
 }
 
-
 var convertCmd = &cobra.Command{
 	Use: "convert [-l language] input_file",
 	Example: `speechly convert my-alexa-skill.json
 speechly convert -l en-US my-alexa-skill.json`,
 	Short: "Converts an Alexa Interaction Model in JSON format to a Speechly configuration",
-	Args: cobra.ExactArgs(1),
+	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := cmd.Context()
 		language, _ := cmd.Flags().GetString("language")

--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -27,7 +27,7 @@ func (u ConvertWriter) Write(data []byte) (n int, err error) {
 }
 
 var convertCmd = &cobra.Command{
-	Use: "convert [-l language] input_file",
+	Use: "convert [-l language] <input_file>",
 	Example: `speechly convert my-alexa-skill.json
 speechly convert -l en-US my-alexa-skill.json`,
 	Short: "Converts an Alexa Interaction Model in JSON format to a Speechly configuration",

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -14,8 +14,19 @@ import (
 )
 
 var deleteCmd = &cobra.Command{
-	Use:   "delete",
+	Use:   "delete [<app_id>]",
 	Short: "Delete an existing application",
+	Args:  cobra.RangeArgs(0, 1),
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		appId, err := cmd.Flags().GetString("app")
+		if err != nil {
+			log.Fatalf("Missing app ID: %s", err)
+		}
+		if appId == "" && len(args) < 1 {
+			return fmt.Errorf("app_id must be given with flag --app or as the sole positional argument")
+		}
+		return nil
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		force, err := cmd.Flags().GetBool("force")
 		if err != nil {
@@ -30,6 +41,9 @@ var deleteCmd = &cobra.Command{
 		id, err := cmd.Flags().GetString("app")
 		if err != nil {
 			log.Fatalf("Missing app ID: %s", err)
+		}
+		if id == "" {
+			id = args[0]
 		}
 
 		ctx := cmd.Context()
@@ -81,11 +95,7 @@ var deleteCmd = &cobra.Command{
 }
 
 func init() {
-	deleteCmd.Flags().StringP("app", "a", "", "application ID to delete")
-	if err := deleteCmd.MarkFlagRequired("app"); err != nil {
-		log.Fatalf("Internal error: %s", err)
-	}
-
+	deleteCmd.Flags().StringP("app", "a", "", "application ID to delete. Can alternatively be given as the sole positional argument.")
 	deleteCmd.Flags().BoolP("force", "f", false, "skip confirmation prompt")
 	deleteCmd.Flags().BoolP("dry-run", "d", false, "don't perform the deletion")
 

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -26,9 +26,9 @@ func (u DeployWriter) Write(data []byte) (n int, err error) {
 }
 
 var deployCmd = &cobra.Command{
-	Use: "deploy <directory> [<app_id>]",
+	Use: "deploy [<app_id>] <directory>",
 	Example: `speechly deploy . -a <app_id>
-speechly deploy /usr/local/project/app <app_id>`,
+speechly deploy <app_id> /usr/local/project/app`,
 	Short: "Send the contents of a local directory to training",
 	Long: `The contents of the directory given as argument is sent to the
 API and validated. Then, a new model is trained and automatically deployed
@@ -48,7 +48,8 @@ as the active model for the application.`,
 		appId, _ := cmd.Flags().GetString("app")
 		inputDirectory := args[0]
 		if appId == "" {
-			appId = args[1]
+			appId = args[0]
+			inputDirectory = args[1]
 		}
 		absPath, _ := filepath.Abs(inputDirectory)
 		log.Printf("Project dir: %s\n", absPath)

--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -10,13 +10,17 @@ import (
 )
 
 var describeCmd = &cobra.Command{
-	Use:   "describe",
-	Short: "Print details about an application",
-	Args:  cobra.NoArgs,
+	Use:     "describe [<app_id>]",
+	Short:   "Print details about an application",
+	Args:    cobra.RangeArgs(0, 1),
+	PreRunE: checkSoleAppArgument,
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := cmd.Context()
 		appId, _ := cmd.Flags().GetString("app")
 		wait, _ := cmd.Flags().GetBool("watch")
+		if appId == "" {
+			appId = args[0]
+		}
 
 		configClient, err := clients.ConfigClient(ctx)
 		if err != nil {
@@ -40,9 +44,6 @@ var describeCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(describeCmd)
-	describeCmd.Flags().StringP("app", "a", "", "Application id to describe")
-	if err := describeCmd.MarkFlagRequired("app"); err != nil {
-		log.Fatalf("failed to init flags: %v", err)
-	}
+	describeCmd.Flags().StringP("app", "a", "", "Application id to describe. Can alternatively be given as the sole positional argument.")
 	describeCmd.Flags().BoolP("watch", "w", false, "If app status is training, wait until it is finished.")
 }

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -34,10 +34,28 @@ version.`,
 		if err != nil {
 			log.Fatalf("Error connecting to API: %s", err)
 		}
-
-		if err := os.RemoveAll(outDir); err != nil {
-			log.Fatalf("Could not clear the download directory %s: %s", outDir, err)
+		d, err := os.Open(outDir)
+		if err != nil {
+			log.Fatalf("Reading output directory failed: %s", err)
 		}
+		defer func() {
+			_ = d.Close()
+		}()
+		names, err := d.Readdirnames(-1)
+		if err != nil {
+			log.Fatalf("Reading output directory failed: %s", err)
+		}
+		for _, name := range names {
+			err = os.RemoveAll(filepath.Join(outDir, name))
+			if err != nil {
+				log.Fatalf("Deleting output directory contents failed: %s", err)
+			}
+		}
+		err = d.Close()
+		if err != nil {
+			log.Fatalf("Reading output directory failed: %s", err)
+		}
+
 		if err := os.MkdirAll(outDir, 0755); err != nil {
 			log.Fatalf("Could not create the download directory %s: %s", outDir, err)
 		}

--- a/cmd/evaluate.go
+++ b/cmd/evaluate.go
@@ -31,7 +31,7 @@ var evaluateCmd = &cobra.Command{
 func EvaluateAnnotatedUtterances(annotatedData []string, groundTruthData []string) {
 	if len(annotatedData) != len(groundTruthData) {
 		log.Fatalf(
-			"Input files should have same length, but --annotated has %d lines and --ground-truth %d lines.",
+			"Input files should have same length, but --input has %d lines and --ground-truth %d lines.",
 			len(annotatedData),
 			len(groundTruthData),
 		)

--- a/cmd/evaluate.go
+++ b/cmd/evaluate.go
@@ -8,7 +8,7 @@ import (
 )
 
 var evaluateCmd = &cobra.Command{
-	Use:     "evaluate",
+	Use:     "evaluate [<app_id>] [<input_file>]",
 	Example: `speechly evaluate --input output.txt --ground-truth ground-truth.txt`,
 	Short:   "Compute accuracy between annotated examples (given by 'speechly annotate') and ground truth.",
 	Args:    cobra.NoArgs,

--- a/cmd/evaluate.go
+++ b/cmd/evaluate.go
@@ -11,7 +11,7 @@ var evaluateCmd = &cobra.Command{
 	Use:     "evaluate",
 	Example: `speechly evaluate --input output.txt --ground-truth ground-truth.txt`,
 	Short:   "Compute accuracy between annotated examples (given by 'speechly annotate') and ground truth.",
-	Args: cobra.NoArgs,
+	Args:    cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		annotatedFn, err := cmd.Flags().GetString("input")
 		if err != nil || len(annotatedFn) == 0 {
@@ -24,33 +24,37 @@ var evaluateCmd = &cobra.Command{
 		}
 		annotatedData := readLines(annotatedFn)
 		groundTruthData := readLines(groundTruthFn)
-		if len(annotatedData) != len(groundTruthData) {
-			log.Fatalf(
-				"Input files should have same length, but --annotated has %d lines and --ground-truth %d lines.",
-				len(annotatedData),
-				len(groundTruthData),
-			)
-		}
-
-		n := float64(len(annotatedData))
-		hits := 0.0
-		for i, aUtt := range annotatedData {
-			gtUtt := groundTruthData[i]
-			if aUtt == gtUtt {
-				hits += 1.0
-				continue
-			}
-			fmt.Println("Ground truth had:")
-			fmt.Println("  " + gtUtt)
-			fmt.Println("but prediction was:")
-			fmt.Println("  " + aUtt)
-			fmt.Println()
-		}
-		fmt.Println("Matching rows out of total: ")
-		fmt.Printf("%.0f / %.0f\n", hits, n)
-		fmt.Println("Accuracy:")
-		fmt.Printf("%.2f\n", hits/n)
+		EvaluateAnnotatedUtterances(annotatedData, groundTruthData)
 	},
+}
+
+func EvaluateAnnotatedUtterances(annotatedData []string, groundTruthData []string) {
+	if len(annotatedData) != len(groundTruthData) {
+		log.Fatalf(
+			"Input files should have same length, but --annotated has %d lines and --ground-truth %d lines.",
+			len(annotatedData),
+			len(groundTruthData),
+		)
+	}
+
+	n := float64(len(annotatedData))
+	hits := 0.0
+	for i, aUtt := range annotatedData {
+		gtUtt := groundTruthData[i]
+		if aUtt == gtUtt {
+			hits += 1.0
+			continue
+		}
+		fmt.Println("Ground truth had:")
+		fmt.Println("  " + gtUtt)
+		fmt.Println("but prediction was:")
+		fmt.Println("  " + aUtt)
+		fmt.Println()
+	}
+	fmt.Println("Matching rows out of total: ")
+	fmt.Printf("%.0f / %.0f\n", hits, n)
+	fmt.Println("Accuracy:")
+	fmt.Printf("%.2f\n", hits/n)
 }
 
 func init() {

--- a/cmd/evaluate.go
+++ b/cmd/evaluate.go
@@ -45,7 +45,7 @@ func EvaluateAnnotatedUtterances(annotatedData []string, groundTruthData []strin
 			hits += 1.0
 			continue
 		}
-		fmt.Println("Ground truth had:")
+		fmt.Printf("Line %d: Ground truth had:\n", i+1)
 		fmt.Println("  " + gtUtt)
 		fmt.Println("but prediction was:")
 		fmt.Println("  " + aUtt)

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -6,10 +6,10 @@ import (
 	"log"
 	"text/tabwriter"
 
-	"github.com/spf13/cobra"
-
 	configv1 "github.com/speechly/api/go/speechly/config/v1"
 	"github.com/speechly/cli/pkg/clients"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 var listCmd = &cobra.Command{
@@ -39,6 +39,30 @@ var listCmd = &cobra.Command{
 			}
 		} else {
 			cmd.Printf("No applications found.\n")
+		}
+
+		// If the project name in settings is automatically generated, update it from server.
+		conf := clients.GetConfig(cmd.Context())
+		currentContextName := viper.Get("current-context")
+		if projectName != currentContextName {
+			ixdToUpdate := -1
+			for ixd, c := range conf.Contexts {
+				if c.Name == currentContextName {
+					ixdToUpdate = ixd
+					break
+				}
+			}
+			if ixdToUpdate >= 0 {
+				if conf.Contexts[ixdToUpdate].Name == conf.Contexts[ixdToUpdate].RemoteName {
+					conf.Contexts[ixdToUpdate].Name = projectName
+					viper.Set("current-context", projectName)
+				}
+				conf.Contexts[ixdToUpdate].RemoteName = projectName
+				viper.Set("contexts", conf.Contexts)
+				if err := viper.WriteConfig(); err != nil {
+					log.Fatalf("Failed to write settings: %s", err)
+				}
+			}
 		}
 	},
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -45,19 +45,19 @@ var listCmd = &cobra.Command{
 		conf := clients.GetConfig(cmd.Context())
 		currentContextName := viper.Get("current-context")
 		if projectName != currentContextName {
-			ixdToUpdate := -1
-			for ixd, c := range conf.Contexts {
+			idxToUpdate := -1
+			for idx, c := range conf.Contexts {
 				if c.Name == currentContextName {
-					ixdToUpdate = ixd
+					idxToUpdate = idx
 					break
 				}
 			}
-			if ixdToUpdate >= 0 {
-				if conf.Contexts[ixdToUpdate].Name == conf.Contexts[ixdToUpdate].RemoteName {
-					conf.Contexts[ixdToUpdate].Name = projectName
+			if idxToUpdate >= 0 {
+				if conf.Contexts[idxToUpdate].Name == conf.Contexts[idxToUpdate].RemoteName {
+					conf.Contexts[idxToUpdate].Name = projectName
 					viper.Set("current-context", projectName)
 				}
-				conf.Contexts[ixdToUpdate].RemoteName = projectName
+				conf.Contexts[idxToUpdate].RemoteName = projectName
 				viper.Set("contexts", conf.Contexts)
 				if err := viper.WriteConfig(); err != nil {
 					log.Fatalf("Failed to write settings: %s", err)

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -50,10 +50,9 @@ func init() {
 func printApps(out io.Writer, apps ...*configv1.App) error {
 	// Format in tab-separated columns with a tab stop of 8.
 	w := tabwriter.NewWriter(out, 0, 8, 1, '\t', 0)
-
-	fmt.Fprint(w, "APP ID\tSTATUS\tNAME\n")
+	fmt.Fprint(w, "NAME\tAPP ID\tSTATUS\n")
 	for _, app := range apps {
-		fmt.Fprintf(w, "%s\t%s\t%s\n", app.GetId(), app.GetStatus(), app.GetName())
+		fmt.Fprintf(w, "%-*.*s\t%s\t%s\n", 48, 48, app.GetName(), app.GetId(), app.GetStatus())
 	}
 
 	return w.Flush()

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -27,11 +27,12 @@ var listCmd = &cobra.Command{
 			log.Fatalf("Getting projects failed: %s", err)
 		}
 		project := projects.Project[0]
+		projectName := projects.ProjectNames[0]
 		apps, err := configClient.ListApps(ctx, &configv1.ListAppsRequest{Project: project})
 		if err != nil {
 			log.Fatalf("Listing apps for project %s failed: %s", project, err)
 		}
-		cmd.Printf("List of applications in project %s:\n\n", project)
+		cmd.Printf("List of applications in project \"%s\" (%s):\n\n", projectName, project)
 		if a := apps.GetApps(); len(a) > 0 {
 			if err := printApps(cmd.OutOrStdout(), a...); err != nil {
 				log.Fatalf("Error listing apps: %s", err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,7 +28,7 @@ var logo = `
 `
 
 func failWithError(err error) {
-	log.Fatalf("General failure; check your configuration with `speechly config`\n\nError: %v", err)
+	log.Fatalf("General failure; check your project settings with `speechly project`\n\nError: %v", err)
 }
 
 func Execute() error {

--- a/cmd/sample.go
+++ b/cmd/sample.go
@@ -34,10 +34,10 @@ func (u CompileWriter) Write(data []byte) (n int, err error) {
 }
 
 var sampleCmd = &cobra.Command{
-	Use: "sample <directory> [<app_id>]",
+	Use: "sample [<app_id>] <directory>",
 	Example: `speechly sample -a UUID_APP_ID .
 speechly sample -a UUID_APP_ID /usr/local/project/app
-speechly sample -a UUID_APP_ID /usr/local/project/app --stats`,
+speechly sample UUID_APP_ID /usr/local/project/app --stats`,
 	Short: "Sample a set of examples from the given SAL configuration",
 	Long: `The contents of the directory given as argument is sent to the
 API and compiled. If configuration is valid, a set of examples are printed to stdout.`,
@@ -54,8 +54,10 @@ API and compiled. If configuration is valid, a set of examples are printed to st
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := cmd.Context()
 		appId, _ := cmd.Flags().GetString("app")
+		inputDir := args[0]
 		if appId == "" {
-			appId = args[1]
+			appId = args[0]
+			inputDir = args[1]
 		}
 		batchSize, _ := cmd.Flags().GetInt("batch-size")
 		if batchSize < 32 || batchSize > 10000 {
@@ -63,7 +65,7 @@ API and compiled. If configuration is valid, a set of examples are printed to st
 		}
 		seed, _ := cmd.Flags().GetInt("seed")
 
-		uploadData := upload.CreateTarFromDir(args[0])
+		uploadData := upload.CreateTarFromDir(inputDir)
 
 		if len(uploadData.Files) == 0 {
 			log.Fatal("No files to upload!\n\nPlease ensure the files are named *.yaml or *.csv")
@@ -409,7 +411,7 @@ func printStats(out io.Writer, examples []string, normal bool, advanced bool, li
 
 func init() {
 	rootCmd.AddCommand(sampleCmd)
-	sampleCmd.Flags().StringP("app", "a", "", "application to sample the files from. Can alternatively be given as the last positional argument")
+	sampleCmd.Flags().StringP("app", "a", "", "application to sample the files from. Can alternatively be given as the first positional argument")
 	sampleCmd.Flags().Int("batch-size", 100, "how many examples to return. Must be between 32 and 10000")
 	sampleCmd.Flags().Int("seed", 0, "random seed to use when initializing the sampler.")
 

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -28,9 +28,9 @@ func (u ValidateWriter) Write(data []byte) (n int, err error) {
 }
 
 var validateCmd = &cobra.Command{
-	Use: "validate <directory> [<app_id>]",
+	Use: "validate [<app_id>] <directory>",
 	Example: `speechly validate -a UUID_APP_ID .
-speechly validate -a UUID_APP_ID /usr/local/project/app`,
+speechly validate UUID_APP_ID /usr/local/project/app`,
 	Short: "Validate the given configuration for syntax errors",
 	Long: `The contents of the directory given as argument is sent to the
 API and validated. Possible errors are printed to stdout.`,
@@ -47,10 +47,11 @@ API and validated. Possible errors are printed to stdout.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := cmd.Context()
 		appId, _ := cmd.Flags().GetString("app")
-		if appId == "" {
-			appId = args[1]
-		}
 		inDir := args[0]
+		if appId == "" {
+			appId = args[0]
+			inDir = args[1]
+		}
 		absPath, _ := filepath.Abs(inDir)
 		log.Printf("Project dir: %s\n", absPath)
 		// create a tar package from files in memory
@@ -98,5 +99,5 @@ func validateUploadData(ctx context.Context, appId string, ud upload.UploadData)
 
 func init() {
 	rootCmd.AddCommand(validateCmd)
-	validateCmd.Flags().StringP("app", "a", "", "application to validate the files for. Can alternatively be given as the last positional argument.")
+	validateCmd.Flags().StringP("app", "a", "", "application to validate the files for. Can alternatively be given as the first positional argument.")
 }

--- a/pkg/clients/config.go
+++ b/pkg/clients/config.go
@@ -69,23 +69,23 @@ func getSpeechlyConfig() (*Config, error) {
 	viper.AutomaticEnv()
 
 	if err := viper.ReadInConfig(); err != nil {
-		if len(os.Args) < 2 || (os.Args[1] != "config" && os.Args[1] != "projects") {
-			log.Print("Please create a configuration file first:\n\n")
-			log.Printf("\t%s projects add --apikey APIKEY --name NAME\n\n", os.Args[0])
+		if len(os.Args) < 2 || (os.Args[1] != "config" && os.Args[1] != "project") {
+			log.Print("Please create a project settings file first:\n\n")
+			log.Printf("\t%s project add --apikey APIKEY --name NAME\n\n", os.Args[0])
 			log.Println("or, alternatively, set the api key as env variable `SPEECHLY_APIKEY`.")
 			os.Exit(1)
 		}
 		// viper has a problem with non-existent config files, just touch the default:
 		file, err := os.Create(filepath.Join(home, ".speechly.yaml"))
 		if err != nil {
-			return nil, fmt.Errorf("Could not initialize speechly config file: %s", err)
+			return nil, fmt.Errorf("could not initialize Speechly project settings file: %s", err)
 		}
 		if err := file.Close(); err != nil {
-			return nil, fmt.Errorf("Could not write speechly config file: %v", err)
+			return nil, fmt.Errorf("could not write Speechly project settings file: %v", err)
 		}
 	} else {
 		if err := viper.Unmarshal(&conf); err != nil {
-			return nil, fmt.Errorf("Failed to unmarshal config file %s: %s", viper.ConfigFileUsed(), err)
+			return nil, fmt.Errorf("failed to unmarshal Speechly project settings file %s: %s", viper.ConfigFileUsed(), err)
 		}
 	}
 	return &conf, nil

--- a/pkg/clients/config.go
+++ b/pkg/clients/config.go
@@ -69,10 +69,10 @@ func getSpeechlyConfig() (*Config, error) {
 	viper.AutomaticEnv()
 
 	if err := viper.ReadInConfig(); err != nil {
-		if len(os.Args) < 2 || os.Args[1] != "config" {
+		if len(os.Args) < 2 || (os.Args[1] != "config" && os.Args[1] != "projects") {
 			log.Print("Please create a configuration file first:\n\n")
-			log.Printf("\t%s config add --apikey APIKEY --name NAME\n\n", os.Args[0])
-			log.Println("or, alternatively, set the api key as env varialbe `SPEECHLY_APIKEY`.")
+			log.Printf("\t%s projects add --apikey APIKEY --name NAME\n\n", os.Args[0])
+			log.Println("or, alternatively, set the api key as env variable `SPEECHLY_APIKEY`.")
 			os.Exit(1)
 		}
 		// viper has a problem with non-existent config files, just touch the default:

--- a/pkg/clients/config.go
+++ b/pkg/clients/config.go
@@ -16,9 +16,10 @@ type Config struct {
 }
 
 type SpeechlyContext struct {
-	Name   string `mapstructure:"name"`
-	Host   string `mapstructure:"host"`
-	Apikey string `mapstructure:"apikey"`
+	Name       string `mapstructure:"name"`
+	Host       string `mapstructure:"host"`
+	Apikey     string `mapstructure:"apikey"`
+	RemoteName string `mapstructure:"remotename"`
 }
 
 func (conf *Config) GetSpeechlyContext() *SpeechlyContext {

--- a/pkg/clients/context.go
+++ b/pkg/clients/context.go
@@ -27,9 +27,9 @@ const (
 )
 
 var (
-	ErrNoConfig        = errors.New("no speechly config found")
-	ErrNoContext       = errors.New("no context specified")
-	ErrContextNotFound = errors.New("defined context not found in config")
+	ErrNoConfig        = errors.New("no Speechly project settings found")
+	ErrNoContext       = errors.New("no project specified")
+	ErrContextNotFound = errors.New("selected project not found in Speechly project settings file")
 
 	ConnectionTimeout = 4 * time.Second
 )


### PR DESCRIPTION
- Add project name to `list` output
- Show line number when reporting evaluation errors
- `annotate` to support
    - SAL-annotated utterances as input (removing the need for separate "ground truth" file) (`--pre-annotated`)
    - removing the annotations from input (`--de-annotate`)
    - using STDIN for `--input`
    - `--evaluate` which works as the separate `evaluate` when `--pre-annotated` is used
  
Edit: Second batch of improvements:

- Changes the column order of `list`
- Replaced term _context_ with _project_ for more consistency with dashboard
- Made `speechly projects` as an alias for `speechly config`
- Removed `--pre-annotated` as running it for non-SAL-annotated valid input is a NOP, so it can be run anyways
- Support `speechly config use` without giving the `--name` in which case it'll ask which of the configured projects to use