### PR TITLE
Fix typo in projects example command

### DIFF
--- a/pkg/clients/config.go
+++ b/pkg/clients/config.go
@@ -72,7 +72,7 @@ func getSpeechlyConfig() (*Config, error) {
 	if err := viper.ReadInConfig(); err != nil {
 		if len(os.Args) < 2 || (os.Args[1] != "config" && os.Args[1] != "project") {
 			log.Print("Please create a project settings file first:\n\n")
-			log.Printf("\t%s project add --apikey APIKEY --name NAME\n\n", os.Args[0])
+			log.Printf("\t%s projects add --apikey APIKEY --name NAME\n\n", os.Args[0])
 			log.Println("or, alternatively, set the api key as env variable `SPEECHLY_APIKEY`.")
 			os.Exit(1)
 		}


### PR DESCRIPTION
It's "projects" not "project"