### PR TITLE
Fix deannotate with certain values

### DIFF
--- a/cmd/annotate.go
+++ b/cmd/annotate.go
@@ -155,6 +155,9 @@ To evaluate already deployed Speechly app, you need a set of evaluation examples
 }
 
 func removeAnnotations(line string) string {
+	removeNormalizedPattern := regexp.MustCompile(`\|.+?]\(([^)]+)\)`)
+	line = removeNormalizedPattern.ReplaceAllString(line, "]")
+
 	removablePattern := regexp.MustCompile(`\*([^ ]+)(?: |$)|\(([^)]+)\)`)
 	line = removablePattern.ReplaceAllString(line, "")
 


### PR DESCRIPTION
Now that the normalised entity values can have rather arbitrary content, the old denotation regex is not sufficient. 