### PR TITLE
Adding initial project apikey fails

### DIFF
--- a/pkg/clients/config.go
+++ b/pkg/clients/config.go
@@ -70,7 +70,7 @@ func getSpeechlyConfig() (*Config, error) {
 	viper.AutomaticEnv()
 
 	if err := viper.ReadInConfig(); err != nil {
-		if len(os.Args) < 2 || (os.Args[1] != "config" && os.Args[1] != "project") {
+		if len(os.Args) < 2 || (os.Args[1] != "config" && os.Args[1] != "projects") {
 			log.Print("Please create a project settings file first:\n\n")
 			log.Printf("\t%s projects add --apikey APIKEY --name NAME\n\n", os.Args[0])
 			log.Println("or, alternatively, set the api key as env variable `SPEECHLY_APIKEY`.")


### PR DESCRIPTION
...because there is a typo in the command name in validation.