### PR TITLE
Harmonize `download` and `deploy` commands

### DIFF
--- a/cmd/annotate.go
+++ b/cmd/annotate.go
@@ -20,9 +20,9 @@ import (
 
 var annotateCmd = &cobra.Command{
 	Use: "annotate [<input file>] [<app id>]",
-	Example: `speechly annotate -a APP_ID --input input.txt
-speechly annotate -a APP_ID --input input.txt > output.txt
-speechly annotate -a APP_ID --reference-date 2021-01-20 --input input.txt > output.txt
+	Example: `speechly annotate -a <app_id> --input input.txt
+speechly annotate -a <app_id> --input input.txt > output.txt
+speechly annotate -a <app_id> --reference-date 2021-01-20 --input input.txt > output.txt
 
 To evaluate already deployed Speechly app, you need a set of evaluation examples that users of your application might say.`,
 	Short: "Create SAL annotations for a list of examples using Speechly.",
@@ -199,12 +199,12 @@ func scanLines(file *os.File) []string {
 
 func init() {
 	rootCmd.AddCommand(annotateCmd)
-	annotateCmd.Flags().StringP("app", "a", "", "app id of the application to evaluate. Can alternatively be given as the first positional argument")
-	annotateCmd.Flags().StringP("input", "i", "", "evaluation utterances, separated by newline, if not provided, read from stdin. Can alternatively be given as the first positional argument.")
-	annotateCmd.Flags().StringP("output", "o", "", "where to store annotated utterances, if not provided, print to stdout.")
-	annotateCmd.Flags().StringP("reference-date", "r", "", "reference date in YYYY-MM-DD format, if not provided use current date.")
-	annotateCmd.Flags().BoolP("de-annotate", "d", false, "instead of adding annotation, remove annotations from output.")
-	annotateCmd.Flags().BoolP("evaluate", "e", false, "print evaluation stats instead of the annotated output.")
+	annotateCmd.Flags().StringP("app", "a", "", "App ID of the application to evaluate. Can alternatively be given as the first positional argument.")
+	annotateCmd.Flags().StringP("input", "i", "", "Evaluation utterances, separated by newline, if not provided, read from stdin. Can alternatively be given as the first positional argument.")
+	annotateCmd.Flags().StringP("output", "o", "", "Where to store annotated utterances, if not provided, print to stdout.")
+	annotateCmd.Flags().StringP("reference-date", "r", "", "Reference date in YYYY-MM-DD format, if not provided use current date.")
+	annotateCmd.Flags().BoolP("de-annotate", "d", false, "Instead of adding annotation, remove annotations from output.")
+	annotateCmd.Flags().BoolP("evaluate", "e", false, "Print evaluation stats instead of the annotated output.")
 }
 
 func printEvalResultTXT(out io.Writer, items []*wluv1.WLUResponse) error {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -222,19 +222,19 @@ func ensureContextExists(ctx context.Context, name string) error {
 }
 
 func init() {
-	configAddCmd.Flags().String("apikey", "", "API key, created in dashboard. Can also be given as the sole positional argument")
-	configAddCmd.Flags().String("name", "", "An unique name for the project. If not given the project name configured in Dashboard will be used.")
+	configAddCmd.Flags().String("apikey", "", "API key, created in Speechly Dashboard. Can also be given as the sole positional argument.")
+	configAddCmd.Flags().String("name", "", "An unique name for the project. If not given the project name configured in Speechly Dashboard will be used.")
 	configAddCmd.Flags().String("host", "api.speechly.com", "API address")
 	configAddCmd.Flags().Bool("skip-online-validation", false, "Skips validating the API key against the host.")
 	configCmd.AddCommand(configAddCmd)
 
-	configRemoveCmd.Flags().String("name", "", "The name for the project for which access is to be removed")
+	configRemoveCmd.Flags().String("name", "", "The name for the project for which access is to be removed.")
 	if err := configRemoveCmd.MarkFlagRequired("name"); err != nil {
 		log.Fatalf("failed to init flags: %v", err)
 	}
 	configCmd.AddCommand(configRemoveCmd)
 
-	configUseCmd.Flags().String("name", "", "An unique name for the project")
+	configUseCmd.Flags().String("name", "", "An unique name for the project.")
 	configCmd.AddCommand(configUseCmd)
 
 	rootCmd.AddCommand(configCmd)

--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -85,5 +85,5 @@ speechly convert -l en-US my-alexa-skill.json`,
 
 func init() {
 	rootCmd.AddCommand(convertCmd)
-	convertCmd.Flags().StringP("language", "l", "", "language of input, defaults to en-US if not given.")
+	convertCmd.Flags().StringP("language", "l", "en-US", "Language of input")
 }

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -81,7 +81,7 @@ var createCmd = &cobra.Command{
 }
 
 func init() {
-	createCmd.Flags().StringP("language", "l", "", "application language (current only 'en-US' and 'fi-FI' are supported). Default en-US")
-	createCmd.Flags().StringP("name", "n", "", "application name, can alternatively be given as the sole positional argument")
+	createCmd.Flags().StringP("language", "l", "en-US", "Application language. Current only 'en-US' and 'fi-FI' are supported.")
+	createCmd.Flags().StringP("name", "n", "", "Application name, can alternatively be given as the sole positional argument.")
 	rootCmd.AddCommand(createCmd)
 }

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -56,6 +56,7 @@ var deleteCmd = &cobra.Command{
 			log.Fatalf("Getting projects failed: %s", err)
 		}
 		project := projects.Project[0]
+		projectName := projects.ProjectNames[0]
 		apps, err := configClient.ListApps(ctx, &configv1.ListAppsRequest{Project: project})
 		if err != nil {
 			log.Fatalf("Getting apps for project %s failed: %s", project, err)
@@ -63,7 +64,7 @@ var deleteCmd = &cobra.Command{
 
 		if appList := apps.GetApps(); len(appList) > 0 {
 			if !appIdInAppList(id, appList) {
-				cmd.Printf("App ID '%s' does not exist. Your project has the following applications:\n\n", id)
+				cmd.Printf("App ID '%s' does not exist.\n\nApplications in project \"%s\" (%s):\n\n", id, projectName, project)
 				if err := printApps(cmd.OutOrStdout(), appList...); err != nil {
 					log.Fatalf("Error listing app: %s", err)
 				}

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -63,7 +63,7 @@ var deleteCmd = &cobra.Command{
 
 		if appList := apps.GetApps(); len(appList) > 0 {
 			if !appIdInAppList(id, appList) {
-				cmd.Printf("App id '%s' does not exist. Your project has apps: \n", id)
+				cmd.Printf("App ID '%s' does not exist. Your project has the following applications:\n\n", id)
 				if err := printApps(cmd.OutOrStdout(), appList...); err != nil {
 					log.Fatalf("Error listing app: %s", err)
 				}
@@ -95,9 +95,9 @@ var deleteCmd = &cobra.Command{
 }
 
 func init() {
-	deleteCmd.Flags().StringP("app", "a", "", "application ID to delete. Can alternatively be given as the sole positional argument.")
-	deleteCmd.Flags().BoolP("force", "f", false, "skip confirmation prompt")
-	deleteCmd.Flags().BoolP("dry-run", "d", false, "don't perform the deletion")
+	deleteCmd.Flags().StringP("app", "a", "", "Application ID to delete. Can alternatively be given as the sole positional argument.")
+	deleteCmd.Flags().BoolP("force", "f", false, "Skip confirmation prompt.")
+	deleteCmd.Flags().BoolP("dry-run", "d", false, "Don't perform the deletion.")
 
 	rootCmd.AddCommand(deleteCmd)
 }

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -28,8 +28,8 @@ func (u DeployWriter) Write(data []byte) (n int, err error) {
 
 var deployCmd = &cobra.Command{
 	Use: "deploy [<app_id>] <directory>",
-	Example: `speechly deploy . -a <app_id>
-speechly deploy <app_id> /usr/local/project/app`,
+	Example: `speechly deploy <app_id> /path/to/config
+speechly deploy -a <app_id> .`,
 	Short: "Send the contents of a local directory to training",
 	Long: `The contents of the directory given as argument is sent to the
 API and validated. Then, a new model is trained and automatically deployed
@@ -116,7 +116,7 @@ as the active model for the application.`,
 
 func init() {
 	rootCmd.AddCommand(deployCmd)
-	deployCmd.Flags().StringP("app", "a", "", "application to deploy the files to. Can alternatively be given as the first positional argument.")
-	deployCmd.Flags().BoolP("watch", "w", false, "wait for training to be finished")
-	deployCmd.Flags().Bool("skip-validation", false, "skip the validation step. If there are validation issues, they will not be shown, the deploy will fail silently.")
+	deployCmd.Flags().StringP("app", "a", "", "Application to deploy the files to. Can be given as the first positional argument.")
+	deployCmd.Flags().BoolP("watch", "w", false, "Wait for training to be finished.")
+	deployCmd.Flags().Bool("skip-validation", false, "Skip the validation step. If there are validation issues, they will not be shown, the deploy will fail silently.")
 }

--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -49,6 +49,6 @@ var describeCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(describeCmd)
-	describeCmd.Flags().StringP("app", "a", "", "Application id to describe. Can alternatively be given as the sole positional argument.")
+	describeCmd.Flags().StringP("app", "a", "", "Application ID to describe. Can alternatively be given as the sole positional argument.")
 	describeCmd.Flags().BoolP("watch", "w", false, "If app status is training, wait until it is finished.")
 }

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"log"
@@ -16,25 +17,38 @@ import (
 )
 
 var downloadCmd = &cobra.Command{
-	Use:   "download [<app_id>]",
-	Short: "Get the active configuration of the given app.",
+	Use:   "download [<app_id>] <directory>",
+	Example: `speechly download <app_id> /path/to/config`,
+	Short: "Download the active configuration of the given app.",
 	Long: `Fetches the currently stored configuration from the API. This command
 does not check for validity of the stored configuration, but downloads the latest
 version.`,
-	Args:    cobra.RangeArgs(0, 1),
-	PreRunE: checkSoleAppArgument,
+Args: cobra.RangeArgs(1, 2),
+PreRunE: func(cmd *cobra.Command, args []string) error {
+	appId, _ := cmd.Flags().GetString("app")
+	if appId == "" {
+		if len(args) < 2 {
+			return fmt.Errorf("app_id must be given with flag --app or as the first positional argument of two")
+		}
+	}
+	return nil
+},
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := cmd.Context()
-		outDir, _ := cmd.Flags().GetString("out")
-		outDir, _ = filepath.Abs(outDir)
-
-		log.Printf("Download current configuration to %s\n", outDir)
+		appId, _ := cmd.Flags().GetString("app")
+		outputDirectory := args[0]
+		if appId == "" {
+			appId = args[0]
+			outputDirectory = args[1]
+		}
+		absPath, _ := filepath.Abs(outputDirectory)
+		log.Printf("Download current configuration to %s\n", absPath)
 
 		client, err := clients.ConfigClient(ctx)
 		if err != nil {
 			log.Fatalf("Error connecting to API: %s", err)
 		}
-		d, err := os.Open(outDir)
+		d, err := os.Open(absPath)
 		if err != nil {
 			log.Fatalf("Reading output directory failed: %s", err)
 		}
@@ -46,7 +60,7 @@ version.`,
 			log.Fatalf("Reading output directory failed: %s", err)
 		}
 		for _, name := range names {
-			err = os.RemoveAll(filepath.Join(outDir, name))
+			err = os.RemoveAll(filepath.Join(absPath, name))
 			if err != nil {
 				log.Fatalf("Deleting output directory contents failed: %s", err)
 			}
@@ -56,13 +70,8 @@ version.`,
 			log.Fatalf("Reading output directory failed: %s", err)
 		}
 
-		if err := os.MkdirAll(outDir, 0755); err != nil {
-			log.Fatalf("Could not create the download directory %s: %s", outDir, err)
-		}
-
-		appId, _ := cmd.Flags().GetString("app")
-		if appId == "" {
-			appId = args[0]
+		if err := os.MkdirAll(absPath, 0755); err != nil {
+			log.Fatalf("Could not create the download directory %s: %s", absPath, err)
 		}
 
 		var buf []byte
@@ -86,11 +95,11 @@ version.`,
 		}
 
 		if ct == configv1.DownloadCurrentTrainingDataResponse_CONTENT_TYPE_TAR {
-			if err := upload.ExtractTarToDir(outDir, bytes.NewReader(buf)); err != nil {
+			if err := upload.ExtractTarToDir(absPath, bytes.NewReader(buf)); err != nil {
 				log.Fatalf("Could not extract the configuration: %s", err)
 			}
 		} else {
-			out := filepath.Join(outDir, "config.yaml")
+			out := filepath.Join(absPath, "config.yaml")
 			log.Printf("Writing file %s (%d bytes)\n", out, len(buf))
 			if err := ioutil.WriteFile(out, buf, 0755); err != nil {
 				log.Fatalf("Could not write configuration to %s: %s", out, err)
@@ -101,10 +110,5 @@ version.`,
 
 func init() {
 	rootCmd.AddCommand(downloadCmd)
-	downloadCmd.Flags().StringP("app", "a", "", "Which application's configuration to download")
-	downloadCmd.Flags().StringP("out", "o", "", "directory to write the training data in. All existing contents will be deleted.")
-	if err := downloadCmd.MarkFlagRequired("out"); err != nil {
-		log.Fatalf("failed to init flags: %s", err)
-	}
-
+	downloadCmd.Flags().StringP("app", "a", "", "Which application's configuration to download. Can be given as the first positional argument.")
 }

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -18,7 +18,8 @@ import (
 
 var downloadCmd = &cobra.Command{
 	Use:   "download [<app_id>] <directory>",
-	Example: `speechly download <app_id> /path/to/config`,
+	Example: `speechly download <app_id> /path/to/config
+speechly download -a <app_id> .`,
 	Short: "Download the active configuration of the given app.",
 	Long: `Fetches the currently stored configuration from the API. This command
 does not check for validity of the stored configuration, but downloads the latest

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -46,11 +46,11 @@ var editCmd = &cobra.Command{
 }
 
 func init() {
-	editCmd.Flags().StringP("app", "a", "", "application id")
+	editCmd.Flags().StringP("app", "a", "", "Application ID")
 	if err := editCmd.MarkFlagRequired("app"); err != nil {
 		log.Fatalf("Internal error: %s", err)
 	}
-	editCmd.Flags().StringP("name", "n", "", "application name")
+	editCmd.Flags().StringP("name", "n", "", "Application name")
 
 	rootCmd.AddCommand(editCmd)
 }

--- a/cmd/evaluate.go
+++ b/cmd/evaluate.go
@@ -64,7 +64,7 @@ func init() {
 	if err := evaluateCmd.MarkFlagRequired("input"); err != nil {
 		log.Fatalf("Failed to init flags: %s", err)
 	}
-	evaluateCmd.Flags().StringP("ground-truth", "t", "", "manually verified ground-truths for annotated examples")
+	evaluateCmd.Flags().StringP("ground-truth", "t", "", "Manually verified ground-truths for annotated examples.")
 	if err := evaluateCmd.MarkFlagRequired("ground-truth"); err != nil {
 		log.Fatalf("Failed to init flags: %s", err)
 	}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -32,7 +32,7 @@ var listCmd = &cobra.Command{
 		if err != nil {
 			log.Fatalf("Listing apps for project %s failed: %s", project, err)
 		}
-		cmd.Printf("List of applications in project \"%s\" (%s):\n\n", projectName, project)
+		cmd.Printf("Applications in project \"%s\" (%s):\n\n", projectName, project)
 		if a := apps.GetApps(); len(a) > 0 {
 			if err := printApps(cmd.OutOrStdout(), a...); err != nil {
 				log.Fatalf("Error listing apps: %s", err)

--- a/cmd/sample.go
+++ b/cmd/sample.go
@@ -35,9 +35,9 @@ func (u CompileWriter) Write(data []byte) (n int, err error) {
 
 var sampleCmd = &cobra.Command{
 	Use: "sample [<app_id>] <directory>",
-	Example: `speechly sample -a UUID_APP_ID .
-speechly sample -a UUID_APP_ID /usr/local/project/app
-speechly sample UUID_APP_ID /usr/local/project/app --stats`,
+	Example: `speechly sample -a <app_id> .
+speechly sample -a <app_id> /path/to/config
+speechly sample <app_id> /path/to/config --stats`,
 	Short: "Sample a set of examples from the given SAL configuration",
 	Long: `The contents of the directory given as argument is sent to the
 API and compiled. If configuration is valid, a set of examples are printed to stdout.`,
@@ -411,12 +411,12 @@ func printStats(out io.Writer, examples []string, normal bool, advanced bool, li
 
 func init() {
 	rootCmd.AddCommand(sampleCmd)
-	sampleCmd.Flags().StringP("app", "a", "", "application to sample the files from. Can alternatively be given as the first positional argument")
-	sampleCmd.Flags().Int("batch-size", 100, "how many examples to return. Must be between 32 and 10000")
-	sampleCmd.Flags().Int("seed", 0, "random seed to use when initializing the sampler.")
+	sampleCmd.Flags().StringP("app", "a", "", "Application to sample the files from. Can alternatively be given as the first positional argument.")
+	sampleCmd.Flags().Int("batch-size", 100, "How many examples to return. Must be between 32 and 10000.")
+	sampleCmd.Flags().Int("seed", 0, "Random seed to use when initializing the sampler.")
 
-	sampleCmd.Flags().Bool("stats", false, "print intent and entity distributions to the output.")
-	sampleCmd.Flags().Bool("advanced-stats", false, "print entity type, value and value pair distributions to the output.")
-	sampleCmd.Flags().Int("advanced-stats-limit", 10, "line limit for advanced_stats. The lines are ordered by count.")
+	sampleCmd.Flags().Bool("stats", false, "Print intent and entity distributions to the output.")
+	sampleCmd.Flags().Bool("advanced-stats", false, "Print entity type, value and value pair distributions to the output.")
+	sampleCmd.Flags().Int("advanced-stats-limit", 10, "Line limit for advanced_stats. The lines are ordered by count.")
 	sampleCmd.Flags().SortFlags = false
 }

--- a/cmd/stats.go
+++ b/cmd/stats.go
@@ -21,7 +21,7 @@ import (
 var statsCmd = &cobra.Command{
 	Use: "stats [<app_id>]",
 	Example: `speechly stats [<app_id>]
-speechly stats -a UUID_APP_ID
+speechly stats -a APP_ID
 speechly stats > output.csv
 speechly stats --start-date 2021-03-01 --end-date 2021-04-01`,
 	Short: "Get utterance statistics for the current project or an application in it",
@@ -103,10 +103,10 @@ speechly stats --start-date 2021-03-01 --end-date 2021-04-01`,
 
 func init() {
 	rootCmd.AddCommand(statsCmd)
-	statsCmd.Flags().StringP("app", "a", "", "application to get the statistics for. Can alternatively be given as the sole positional argument.")
-	statsCmd.Flags().String("start-date", "", "start date for statistics.")
-	statsCmd.Flags().String("end-date", "", "end date for statistics, not included in results.")
-	statsCmd.Flags().Bool("export", false, "print report as CSV")
+	statsCmd.Flags().StringP("app", "a", "", "Application to get the statistics for. Can alternatively be given as the sole positional argument.")
+	statsCmd.Flags().String("start-date", "", "Start date for statistics.")
+	statsCmd.Flags().String("end-date", "", "End date for statistics, not included in results.")
+	statsCmd.Flags().Bool("export", false, "Print report as CSV")
 }
 
 func printAnalytics(out io.Writer, agg analyticsv1.Aggregation, items ...*analyticsv1.UtteranceStatisticsPeriod) error {

--- a/cmd/transcribe.go
+++ b/cmd/transcribe.go
@@ -22,7 +22,7 @@ var transcribeCmd = &cobra.Command{
 		if model != "" {
 			err = transcribeOnDevice(strings.Split(model, ","), appID, inputPath)
 			if err != nil {
-				log.Fatalf("Error in On Device Transcription: %s", err)
+				log.Fatalf("Error in On-device Transcription: %s", err)
 			}
 			return
 		}
@@ -32,7 +32,7 @@ var transcribeCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(transcribeCmd)
-	transcribeCmd.Flags().StringP("model", "m", "", "on device model file paths as a comma separated list")
+	transcribeCmd.Flags().StringP("model", "m", "", "On-device model file paths as a comma separated list.")
 }
 
 type AudioCorpusItem struct {

--- a/cmd/transcribe_on_device_not_available.go
+++ b/cmd/transcribe_on_device_not_available.go
@@ -6,5 +6,5 @@ package cmd
 import "fmt"
 
 func transcribeOnDevice(models []string, appID string, corpusPath string) error {
-	return fmt.Errorf("This version of the Speechly CLI tool does not support on device transcription.")
+	return fmt.Errorf("This version of the Speechly CLI tool does not support on-device transcription.")
 }

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -29,8 +29,8 @@ func (u ValidateWriter) Write(data []byte) (n int, err error) {
 
 var validateCmd = &cobra.Command{
 	Use: "validate [<app_id>] <directory>",
-	Example: `speechly validate -a UUID_APP_ID .
-speechly validate UUID_APP_ID /usr/local/project/app`,
+	Example: `speechly validate -a <app_id> .
+speechly validate <app_id> /path/to/config`,
 	Short: "Validate the given configuration for syntax errors",
 	Long: `The contents of the directory given as argument is sent to the
 API and validated. Possible errors are printed to stdout.`,
@@ -99,5 +99,5 @@ func validateUploadData(ctx context.Context, appId string, ud upload.UploadData)
 
 func init() {
 	rootCmd.AddCommand(validateCmd)
-	validateCmd.Flags().StringP("app", "a", "", "application to validate the files for. Can alternatively be given as the first positional argument.")
+	validateCmd.Flags().StringP("app", "a", "", "Application to validate the files for. Can alternatively be given as the first positional argument.")
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -17,12 +17,12 @@ var versionCmd = &cobra.Command{
 	Short: "Print the version number",
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-		cmd.Println(fmt.Sprintf("version: %s", version))
+		cmd.Println(fmt.Sprintf("Version: %s", version))
 		if commit != "" {
-			cmd.Println(fmt.Sprintf("commit: %s", commit))
+			cmd.Println(fmt.Sprintf("Commit: %s", commit))
 		}
 		if date != "" {
-			cmd.Println(fmt.Sprintf("date: %s", date))
+			cmd.Println(fmt.Sprintf("Date: %s", date))
 		}
 	},
 }


### PR DESCRIPTION
## What

Use both `download` and `deploy` commands in the same way:

```
speechly deploy <app_id> <directory> [flags]
speechly download <app_id> <directory> [flags]
```

Note that the `--out` flag will be deprecated after this PR.

At the same go i updated most help texts and descriptions:

- Unify writing of app id's, on-device, etc.
- Capitalize descriptions and helpt texts
- Update examples and error prints

## Why

Currently `deploy` takes a `<directory>` argument, which is very convenient to use:
```
speechly deploy XXXXXXX .
```

Wheres before this PR `download` did not take a directory argument, instead one needed to specify this using the `--out`  flag:
```
speechly download XXXXXXX --out .
```

I found it quite unintuitive to use and constantly found myself looking at the help text when trying to download. Even more annoying was the fact that the only other flags one could give to the download command was `--help` as `--app` was already passed as an argument. 