### PR TITLE
Feat/create dir

### DIFF
--- a/cmd/annotate.go
+++ b/cmd/annotate.go
@@ -199,8 +199,8 @@ func scanLines(file *os.File) []string {
 
 func init() {
 	RootCmd.AddCommand(annotateCmd)
-	annotateCmd.Flags().StringP("app", "a", "", "App ID of the application to evaluate. Can alternatively be given as the first positional argument.")
-	annotateCmd.Flags().StringP("input", "i", "", "Evaluation utterances, separated by newline, if not provided, read from stdin. Can alternatively be given as the first positional argument.")
+	annotateCmd.Flags().StringP("app", "a", "", "Application to evaluate. Can be given as the first positional argument.")
+	annotateCmd.Flags().StringP("input", "i", "", "Evaluation utterances, separated by newline, if not provided, read from stdin. Can be given as the first positional argument.")
 	annotateCmd.Flags().StringP("output", "o", "", "Where to store annotated utterances, if not provided, print to stdout.")
 	annotateCmd.Flags().StringP("reference-date", "r", "", "Reference date in YYYY-MM-DD format, if not provided use current date.")
 	annotateCmd.Flags().BoolP("de-annotate", "d", false, "Instead of adding annotation, remove annotations from output.")

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -58,6 +58,12 @@ var createCmd = &cobra.Command{
 			log.Fatal("Error fetching projects: no projects exist for the given token")
 		}
 
+		skipCreateFile, err := cmd.Flags().GetBool("skip-create-file")
+		if err != nil {
+			log.Fatalf("Missing skip-create-file flag: %s", err)
+		}
+
+		if !skipCreateFile {
 			path, err := os.Getwd()
 			if err != nil {
 				log.Fatalf("Could not access current folder: %s", err)
@@ -76,6 +82,8 @@ var createCmd = &cobra.Command{
 			} else {
 				log.Fatal("Directory 'config' already exists, try using another directory")
 			}
+		}
+
 		projectId := projects.Project[0]
 		projectName := projects.ProjectNames[0]
 
@@ -106,5 +114,6 @@ var createCmd = &cobra.Command{
 func init() {
 	createCmd.Flags().StringP("language", "l", "en-US", "Application language. Current only 'en-US' and 'fi-FI' are supported.")
 	createCmd.Flags().StringP("name", "n", "", "Application name, can alternatively be given as the sole positional argument.")
+	createCmd.Flags().Bool("skip-create-file", false, "Skip creating a 'config/config.yaml' file")
 	RootCmd.AddCommand(createCmd)
 }

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -13,9 +13,12 @@ import (
 )
 
 var createCmd = &cobra.Command{
-	Use:   "create [<application name>]",
+	Use: "create [<application name>]",
+	Example: `speechly create "My App"
+speechly create --name "My App" --output-dir /foo/bar
+`,
 	Short: "Create a new application in the current project",
-	Long:  "Creates a new application in the current project and a `config/config.yaml` file in the current working directory.",
+	Long:  "Creates a new application in the current project and a config file in the current working directory.",
 	Args:  cobra.RangeArgs(0, 1),
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		name, _ := cmd.Flags().GetString("name")
@@ -58,30 +61,26 @@ var createCmd = &cobra.Command{
 			log.Fatal("Error fetching projects: no projects exist for the given token")
 		}
 
-		skipCreateFile, err := cmd.Flags().GetBool("skip-create-file")
-		if err != nil {
-			log.Fatalf("Missing skip-create-file flag: %s", err)
-		}
+		outDir, _ := cmd.Flags().GetString("output-dir")
 
-		if !skipCreateFile {
-			path, err := os.Getwd()
-			if err != nil {
-				log.Fatalf("Could not access current folder: %s", err)
-			}
-			outDir := filepath.Join(path, "config")
+		if outDir == "" || outDir == "." {
+			outDir = "."
+		} else {
+			outDir, _ = filepath.Abs(outDir)
 			if _, err := os.Stat(outDir); os.IsNotExist(err) {
 				if err := os.Mkdir(outDir, os.ModePerm); err != nil {
-					log.Fatalf("Could not create the config directory %s: %s", outDir, err)
-				}
-				buf := []byte("templates: ''\nintents: []\nentities: []\n")
-				out := filepath.Join(outDir, "config.yaml")
-				log.Printf("Writing file %s (%d bytes)\n", out, len(buf))
-				if err := os.WriteFile(out, buf, 0644); err != nil {
-					log.Fatalf("Could not write configuration to %s: %s", out, err)
+					log.Fatalf("Could not create the output directory %s: %s", outDir, err)
 				}
 			} else {
-				log.Fatal("Directory 'config' already exists, try using another directory")
+				log.Fatalf("Directory %s already exists", outDir)
 			}
+		}
+
+		buf := []byte("templates: ''\nintents: []\nentities: []\n")
+		outFile := filepath.Join(outDir, "config.yaml")
+		log.Printf("Writing file %s (%d bytes)\n", outFile, len(buf))
+		if err := os.WriteFile(outFile, buf, 0644); err != nil {
+			log.Fatalf("Could not write configuration to %s: %s", outFile, err)
 		}
 
 		projectId := projects.Project[0]
@@ -114,6 +113,6 @@ var createCmd = &cobra.Command{
 func init() {
 	createCmd.Flags().StringP("language", "l", "en-US", "Application language. Available options are 'en-US' and 'fi-FI'.")
 	createCmd.Flags().StringP("name", "n", "", "Application name. Can be given as the sole positional argument.")
-	createCmd.Flags().Bool("skip-create-file", false, "Skip creating a 'config/config.yaml' file")
+	createCmd.Flags().StringP("output-dir", "o", "", "Output directory for the config file.")
 	RootCmd.AddCommand(createCmd)
 }

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -73,7 +73,7 @@ var createCmd = &cobra.Command{
 				if err := os.Mkdir(outDir, os.ModePerm); err != nil {
 					log.Fatalf("Could not create the config directory %s: %s", outDir, err)
 				}
-				buf := []byte(fmt.Sprintf("lang: %s\ntemplates: ''\nintents: []\nentities: []\n", lang))
+				buf := []byte("templates: ''\nintents: []\nentities: []\n")
 				out := filepath.Join(outDir, "config.yaml")
 				log.Printf("Writing file %s (%d bytes)\n", out, len(buf))
 				if err := os.WriteFile(out, buf, 0644); err != nil {

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -112,8 +112,8 @@ var createCmd = &cobra.Command{
 }
 
 func init() {
-	createCmd.Flags().StringP("language", "l", "en-US", "Application language. Current only 'en-US' and 'fi-FI' are supported.")
-	createCmd.Flags().StringP("name", "n", "", "Application name, can alternatively be given as the sole positional argument.")
+	createCmd.Flags().StringP("language", "l", "en-US", "Application language. Available options are 'en-US' and 'fi-FI'.")
+	createCmd.Flags().StringP("name", "n", "", "Application name. Can be given as the sole positional argument.")
 	createCmd.Flags().Bool("skip-create-file", false, "Skip creating a 'config/config.yaml' file")
 	RootCmd.AddCommand(createCmd)
 }

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -96,7 +96,7 @@ var deleteCmd = &cobra.Command{
 }
 
 func init() {
-	deleteCmd.Flags().StringP("app", "a", "", "Application ID to delete. Can alternatively be given as the sole positional argument.")
+	deleteCmd.Flags().StringP("app", "a", "", "Application to delete. Can be given as the sole positional argument.")
 	deleteCmd.Flags().BoolP("force", "f", false, "Skip confirmation prompt.")
 	deleteCmd.Flags().BoolP("dry-run", "d", false, "Don't perform the deletion.")
 

--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -49,6 +49,6 @@ var describeCmd = &cobra.Command{
 
 func init() {
 	RootCmd.AddCommand(describeCmd)
-	describeCmd.Flags().StringP("app", "a", "", "Application ID to describe. Can alternatively be given as the sole positional argument.")
+	describeCmd.Flags().StringP("app", "a", "", "Application to describe. Can be given as the sole positional argument.")
 	describeCmd.Flags().BoolP("watch", "w", false, "If app status is training, wait until it is finished.")
 }

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -46,7 +46,7 @@ var editCmd = &cobra.Command{
 }
 
 func init() {
-	editCmd.Flags().StringP("app", "a", "", "Application ID")
+	editCmd.Flags().StringP("app", "a", "", "Application to edit")
 	if err := editCmd.MarkFlagRequired("app"); err != nil {
 		log.Fatalf("Internal error: %s", err)
 	}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -11,6 +11,8 @@ import (
 	"github.com/speechly/cli/pkg/clients"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 var listCmd = &cobra.Command{
@@ -75,7 +77,7 @@ func init() {
 func printApps(out io.Writer, apps ...*configv1.App) error {
 	// Format in tab-separated columns with a tab stop of 8.
 	w := tabwriter.NewWriter(out, 0, 8, 1, '\t', 0)
-	fmt.Fprint(w, "NAME\tAPP ID\tSTATUS\tDEPLOYED AT\n")
+	fmt.Fprint(w, "Name\tApp ID\tStatus\tDeployed at\n")
 	for _, app := range apps {
 		deployedAt := ""
 		if app.GetDeployedAtTime() != nil {
@@ -83,9 +85,10 @@ func printApps(out io.Writer, apps ...*configv1.App) error {
 		}
 		status := app.GetStatus().String()
 		if strings.Contains(status, "STATUS_") {
-			status = strings.TrimPrefix(status, "STATUS_")
+			c := cases.Title(language.English)
+			status = c.String(strings.TrimPrefix(status, "STATUS_"))
 		}
-		fmt.Fprintf(w, "%-*.*s\t%s\t%s\t%s\n", 48, 48, app.GetName(), app.GetId(), status, deployedAt)
+		fmt.Fprintf(w, "%-*.*s\t%s\t%s\t%s\n", 16, 32, app.GetName(), app.GetId(), status, deployedAt)
 	}
 
 	return w.Flush()

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"strings"
 	"text/tabwriter"
 
 	configv1 "github.com/speechly/api/go/speechly/config/v1"
@@ -80,7 +81,11 @@ func printApps(out io.Writer, apps ...*configv1.App) error {
 		if app.GetDeployedAtTime() != nil {
 			deployedAt = app.GetDeployedAtTime().AsTime().String()
 		}
-		fmt.Fprintf(w, "%-*.*s\t%s\t%s\t%s\n", 48, 48, app.GetName(), app.GetId(), app.GetStatus(), deployedAt)
+		status := app.GetStatus().String()
+		if strings.Contains(status, "STATUS_") {
+			status = strings.TrimPrefix(status, "STATUS_")
+		}
+		fmt.Fprintf(w, "%-*.*s\t%s\t%s\t%s\n", 48, 48, app.GetName(), app.GetId(), status, deployedAt)
 	}
 
 	return w.Flush()

--- a/cmd/sample.go
+++ b/cmd/sample.go
@@ -411,7 +411,7 @@ func printStats(out io.Writer, examples []string, normal bool, advanced bool, li
 
 func init() {
 	RootCmd.AddCommand(sampleCmd)
-	sampleCmd.Flags().StringP("app", "a", "", "Application to sample the files from. Can alternatively be given as the first positional argument.")
+	sampleCmd.Flags().StringP("app", "a", "", "Application to sample the files from. Can be given as the first positional argument.")
 	sampleCmd.Flags().Int("batch-size", 100, "How many examples to return. Must be between 32 and 10000.")
 	sampleCmd.Flags().Int("seed", 0, "Random seed to use when initializing the sampler.")
 

--- a/cmd/stats.go
+++ b/cmd/stats.go
@@ -103,7 +103,7 @@ speechly stats --start-date 2021-03-01 --end-date 2021-04-01`,
 
 func init() {
 	RootCmd.AddCommand(statsCmd)
-	statsCmd.Flags().StringP("app", "a", "", "Application to get the statistics for. Can alternatively be given as the sole positional argument.")
+	statsCmd.Flags().StringP("app", "a", "", "Application to get the statistics for. Can be given as the sole positional argument.")
 	statsCmd.Flags().String("start-date", "", "Start date for statistics.")
 	statsCmd.Flags().String("end-date", "", "End date for statistics, not included in results.")
 	statsCmd.Flags().Bool("export", false, "Print report as CSV")

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -99,5 +99,5 @@ func validateUploadData(ctx context.Context, appId string, ud upload.UploadData)
 
 func init() {
 	RootCmd.AddCommand(validateCmd)
-	validateCmd.Flags().StringP("app", "a", "", "Application to validate the files for. Can alternatively be given as the first positional argument.")
+	validateCmd.Flags().StringP("app", "a", "", "Application to validate the files for. Can be given as the first positional argument.")
 }

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,0 +1,4 @@
+lang: en-US
+templates: ''
+intents: []
+entities: []

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,4 +1,0 @@
-lang: en-US
-templates: ''
-intents: []
-entities: []

--- a/docs/annotate.md
+++ b/docs/annotate.md
@@ -19,11 +19,11 @@ To evaluate already deployed Speechly app, you need a set of evaluation examples
 ## Options
 
 ```
-  -a, --app string              App ID of the application to evaluate. Can alternatively be given as the first positional argument.
+  -a, --app string              Application to evaluate. Can be given as the first positional argument.
   -d, --de-annotate             Instead of adding annotation, remove annotations from output.
   -e, --evaluate                Print evaluation stats instead of the annotated output.
   -h, --help                    help for annotate
-  -i, --input string            Evaluation utterances, separated by newline, if not provided, read from stdin. Can alternatively be given as the first positional argument.
+  -i, --input string            Evaluation utterances, separated by newline, if not provided, read from stdin. Can be given as the first positional argument.
   -o, --output string           Where to store annotated utterances, if not provided, print to stdout.
   -r, --reference-date string   Reference date in YYYY-MM-DD format, if not provided use current date.
 ```

--- a/docs/create.md
+++ b/docs/create.md
@@ -4,7 +4,7 @@ Create a new application in the current project
 
 ## Synopsis
 
-Creates a new application in the current project and a configuration file in the current working directory.
+Creates a new application in the current project and a `config/config.yaml` file in the current working directory.
 
 ```
 speechly create [<application name>] [flags]
@@ -13,9 +13,10 @@ speechly create [<application name>] [flags]
 ## Options
 
 ```
-  -h, --help              help for create
-  -l, --language string   Application language. Current only 'en-US' and 'fi-FI' are supported. (default "en-US")
-  -n, --name string       Application name, can alternatively be given as the sole positional argument.
+  -h, --help               help for create
+  -l, --language string    Application language. Current only 'en-US' and 'fi-FI' are supported. (default "en-US")
+  -n, --name string        Application name, can alternatively be given as the sole positional argument.
+      --skip-create-file   Skip creating a 'config/config.yaml' file
 ```
 
 ## See also

--- a/docs/create.md
+++ b/docs/create.md
@@ -4,19 +4,27 @@ Create a new application in the current project
 
 ## Synopsis
 
-Creates a new application in the current project and a `config/config.yaml` file in the current working directory.
+Creates a new application in the current project and a config file in the current working directory.
 
 ```
 speechly create [<application name>] [flags]
 ```
 
+## Examples
+
+```
+speechly create "My app"
+speechly create --name "My app" --output-dir /foo/bar
+
+```
+
 ## Options
 
 ```
-  -h, --help               help for create
-  -l, --language string    Application language. Available options are 'en-US' and 'fi-FI'. (default "en-US")
-  -n, --name string        Application name. Can be given as the sole positional argument.
-      --skip-create-file   Skip creating a 'config/config.yaml' file
+  -h, --help                help for create
+  -l, --language string     Application language. Available options are 'en-US' and 'fi-FI'. (default "en-US")
+  -n, --name string         Application name. Can be given as the sole positional argument.
+  -o, --output-dir string   Output directory for the config file.
 ```
 
 ## See also

--- a/docs/create.md
+++ b/docs/create.md
@@ -14,8 +14,8 @@ speechly create [<application name>] [flags]
 
 ```
   -h, --help               help for create
-  -l, --language string    Application language. Current only 'en-US' and 'fi-FI' are supported. (default "en-US")
-  -n, --name string        Application name, can alternatively be given as the sole positional argument.
+  -l, --language string    Application language. Available options are 'en-US' and 'fi-FI'. (default "en-US")
+  -n, --name string        Application name. Can be given as the sole positional argument.
       --skip-create-file   Skip creating a 'config/config.yaml' file
 ```
 

--- a/docs/delete.md
+++ b/docs/delete.md
@@ -9,7 +9,7 @@ speechly delete [<app_id>] [flags]
 ## Options
 
 ```
-  -a, --app string   Application ID to delete. Can alternatively be given as the sole positional argument.
+  -a, --app string   Application to delete. Can be given as the sole positional argument.
   -d, --dry-run      Don't perform the deletion.
   -f, --force        Skip confirmation prompt.
   -h, --help         help for delete

--- a/docs/describe.md
+++ b/docs/describe.md
@@ -9,7 +9,7 @@ speechly describe [<app_id>] [flags]
 ## Options
 
 ```
-  -a, --app string   Application ID to describe. Can alternatively be given as the sole positional argument.
+  -a, --app string   Application to describe. Can be given as the sole positional argument.
   -h, --help         help for describe
   -w, --watch        If app status is training, wait until it is finished.
 ```

--- a/docs/edit.md
+++ b/docs/edit.md
@@ -9,7 +9,7 @@ speechly edit [flags]
 ## Options
 
 ```
-  -a, --app string    Application ID
+  -a, --app string    Application to edit
   -h, --help          help for edit
   -n, --name string   Application name
 ```

--- a/docs/sample.md
+++ b/docs/sample.md
@@ -22,7 +22,7 @@ speechly sample <app_id> /path/to/config --stats
 ## Options
 
 ```
-  -a, --app string                 Application to sample the files from. Can alternatively be given as the first positional argument.
+  -a, --app string                 Application to sample the files from. Can be given as the first positional argument.
       --batch-size int             How many examples to return. Must be between 32 and 10000. (default 100)
       --seed int                   Random seed to use when initializing the sampler.
       --stats                      Print intent and entity distributions to the output.

--- a/docs/stats.md
+++ b/docs/stats.md
@@ -18,7 +18,7 @@ speechly stats --start-date 2021-03-01 --end-date 2021-04-01
 # Options
 
 ```
-  -a, --app string          Application to get the statistics for. Can alternatively be given as the sole positional argument.
+  -a, --app string          Application to get the statistics for. Can be given as the sole positional argument.
       --end-date string     End date for statistics, not included in results.
       --export              Print report as CSV
   -h, --help                help for stats

--- a/docs/validate.md
+++ b/docs/validate.md
@@ -21,7 +21,7 @@ speechly validate <app_id> /path/to/config
 # Options
 
 ```
-  -a, --app string   Application to validate the files for. Can alternatively be given as the first positional argument.
+  -a, --app string   Application to validate the files for. Can be given as the first positional argument.
   -h, --help         help for validate
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/speechly/api/go v0.0.0-20220920060221-2531f4783d08
 	github.com/spf13/cobra v1.3.0
 	github.com/spf13/viper v1.10.0
+	golang.org/x/text v0.3.7
 	google.golang.org/grpc v1.42.0
 	google.golang.org/protobuf v1.27.1
 )
@@ -33,7 +34,6 @@ require (
 	github.com/subosito/gotenv v1.2.0 // indirect
 	golang.org/x/net v0.0.0-20211201190559-0a0e4e1bb54c // indirect
 	golang.org/x/sys v0.0.0-20211205182925-97ca703d548d // indirect
-	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/genproto v0.0.0-20211208223120-3a66f561d7aa // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/ini.v1 v1.66.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -323,8 +323,6 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
-github.com/speechly/api/go v0.0.0-20220120141125-eaafc0a471e9 h1:3GIvsd+/AKQdKuQU4Se4z0pInLuJM6MOhD8Wx37n8ag=
-github.com/speechly/api/go v0.0.0-20220120141125-eaafc0a471e9/go.mod h1:KvNvGseEYbeNswC/9TA8LMQ0vPXGzcuWlY88N3x5V5Y=
 github.com/speechly/api/go v0.0.0-20220920060221-2531f4783d08 h1:zXbl+SvFylqwXwVGsPmu5SAcAU4axL03AYHE8qFQ+10=
 github.com/speechly/api/go v0.0.0-20220920060221-2531f4783d08/go.mod h1:KvNvGseEYbeNswC/9TA8LMQ0vPXGzcuWlY88N3x5V5Y=
 github.com/spf13/afero v1.3.3/go.mod h1:5KUK8ByomD5Ti5Artl0RtHeI5pTF7MIDuXL3yY520V4=


### PR DESCRIPTION
Continuation to PR #51 

As the `deploy` command expects a directory, create a `config` directory for the `config.yaml` file. This makes the first-developer experience even smoother. If the directory exist, the command exits. The file creation can be skipped using the `--skip-create-file` flag.

At the same go cleaned up some typos, improved flags help text writing and nicer app list formatting.