### PR TITLE
Improve evaluate output format

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -15,7 +15,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/aebruno/nwalgo"
 	"github.com/go-audio/audio"
 	"github.com/go-audio/wav"
 	"github.com/schollz/progressbar/v3"
@@ -24,6 +23,7 @@ import (
 	sluv1 "github.com/speechly/api/go/speechly/slu/v1"
 	wluv1 "github.com/speechly/api/go/speechly/slu/v1"
 	"github.com/speechly/cli/pkg/clients"
+	"github.com/speechly/nwalgo"
 	"github.com/spf13/cobra"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -202,7 +202,7 @@ func evaluateAnnotatedUtterances(annotatedData []string, groundTruthData []strin
 	hits := 0.0
 	for i, aUtt := range annotatedData {
 		gtUtt := groundTruthData[i]
-		aln1, aln2, _ := nwalgo.Align(gtUtt, aUtt, 1, -1, -1)
+		aln1, aln2, _ := nwalgo.Align(gtUtt, aUtt, "*", 1, -1, -1)
 		if strings.TrimSpace(aUtt) == strings.TrimSpace(gtUtt) {
 			hits += 1.0
 			continue

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -423,21 +423,19 @@ func getBar(desc string, unit string, inputSize int) *progressbar.ProgressBar {
 		progressbar.OptionThrottle(65*time.Millisecond),
 		progressbar.OptionShowCount(),
 		progressbar.OptionShowIts(),
-		progressbar.OptionOnCompletion(func() {
-			fmt.Fprint(os.Stderr, "\n")
-		}),
 		progressbar.OptionSpinnerType(14),
-		progressbar.OptionFullWidth(),
 		progressbar.OptionSetRenderBlankState(true),
+		progressbar.OptionClearOnFinish(),
 		// Custom Options
+		progressbar.OptionSetWidth(20),
 		progressbar.OptionSetDescription(desc),
 		progressbar.OptionSetItsString(unit),
 		progressbar.OptionSetTheme(progressbar.Theme{
 			Saucer:        "█",
-			SaucerHead:    "▒",
+			SaucerHead:    "▌",
 			SaucerPadding: "░",
-			BarStart:      "▕",
-			BarEnd:        "▏",
+			BarStart:      " ",
+			BarEnd:        " ",
 		}))
 	return bar
 }

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aebruno/nwalgo"
 	"github.com/go-audio/audio"
 	"github.com/go-audio/wav"
 	"github.com/schollz/progressbar/v3"
@@ -201,13 +202,14 @@ func evaluateAnnotatedUtterances(annotatedData []string, groundTruthData []strin
 	hits := 0.0
 	for i, aUtt := range annotatedData {
 		gtUtt := groundTruthData[i]
+		aln1, aln2, _ := nwalgo.Align(gtUtt, aUtt, 1, -1, -1)
 		if strings.TrimSpace(aUtt) == strings.TrimSpace(gtUtt) {
 			hits += 1.0
 			continue
 		}
 		fmt.Printf("\nLine: %d\n", i+1)
-		fmt.Printf("└─ Ground truth: %s\n", gtUtt)
-		fmt.Printf("└─ Prediction:   %s\n", aUtt)
+		fmt.Printf("└─ Ground truth: %s\n", aln1)
+		fmt.Printf("└─ Prediction:   %s\n", aln2)
 	}
 	fmt.Printf("\nAccuracy: %.2f (%.0f/%.0f)\n", hits/n, hits, n)
 }

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -205,11 +205,11 @@ func evaluateAnnotatedUtterances(annotatedData []string, groundTruthData []strin
 			hits += 1.0
 			continue
 		}
-		fmt.Printf("Line: %d\n", i+1)
-		fmt.Printf("Ground truth: %s\n", gtUtt)
-		fmt.Printf("Prediction:   %s\n\n", aUtt)
+		fmt.Printf("\nLine: %d\n", i+1)
+		fmt.Printf("└─ Ground truth: %s\n", gtUtt)
+		fmt.Printf("└─ Prediction:   %s\n", aUtt)
 	}
-	fmt.Printf("Accuracy: %.2f (%.0f/%.0f)\n", hits/n, hits, n)
+	fmt.Printf("\nAccuracy: %.2f (%.0f/%.0f)\n", hits/n, hits, n)
 }
 
 func wluResponsesToString(responses []*wluv1.WLUResponse) []string {

--- a/cmd/evaluate.go
+++ b/cmd/evaluate.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/aebruno/nwalgo"
+	"github.com/speechly/nwalgo"
 	"github.com/spf13/cobra"
 )
 
@@ -65,7 +65,7 @@ var asrCmd = &cobra.Command{
 				log.Fatalf("Error in result generation: %v", err)
 			}
 			if wd.dist > 0 && wd.base > 0 {
-				aln1, aln2, _ := nwalgo.Align(aci.Transcript, aci.Hypothesis, 1, -1, -1)
+				aln1, aln2, _ := nwalgo.Align(aci.Transcript, aci.Hypothesis, "*", 1, -1, -1)
 				fmt.Printf("\nAudio: %s\n", aci.Audio)
 				fmt.Printf("└─ Ground truth: %s\n", aln1)
 				fmt.Printf("└─ Prediction:   %s\n", aln2)

--- a/cmd/evaluate.go
+++ b/cmd/evaluate.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/aebruno/nwalgo"
 	"github.com/spf13/cobra"
 )
 
@@ -64,13 +65,14 @@ var asrCmd = &cobra.Command{
 				log.Fatalf("Error in result generation: %v", err)
 			}
 			if wd.dist > 0 && wd.base > 0 {
-				fmt.Printf("Audio: %s\n", aci.Audio)
-				fmt.Printf("Ground truth: %s\n", aci.Transcript)
-				fmt.Printf("Prediction:   %s\n\n", aci.Hypothesis)
+				aln1, aln2, _ := nwalgo.Align(aci.Transcript, aci.Hypothesis, 1, -1, -1)
+				fmt.Printf("\nAudio: %s\n", aci.Audio)
+				fmt.Printf("└─ Ground truth: %s\n", aln1)
+				fmt.Printf("└─ Prediction:   %s\n", aln2)
 			}
 			ed = ed.Add(wd)
 		}
-		fmt.Printf("Word Error Rate (WER): %.2f (%.0d/%.0d)\n", ed.AsER(), ed.dist, ed.base)
+		fmt.Printf("\nWord Error Rate (WER): %.2f (%.0d/%.0d)\n", ed.AsER(), ed.dist, ed.base)
 	},
 }
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,8 @@ module github.com/speechly/cli
 go 1.17
 
 require (
+	github.com/aebruno/nwalgo v0.0.0-20160817130739-4a232086e3ad
+	github.com/agnivade/levenshtein v1.1.1
 	github.com/go-audio/audio v1.0.0
 	github.com/go-audio/wav v1.1.0
 	github.com/mattn/go-isatty v0.0.16
@@ -17,7 +19,6 @@ require (
 )
 
 require (
-	github.com/agnivade/levenshtein v1.1.1 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.1 // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/go-audio/riff v1.0.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/speechly/cli
 go 1.17
 
 require (
-	github.com/aebruno/nwalgo v0.0.0-20160817130739-4a232086e3ad
 	github.com/agnivade/levenshtein v1.1.1
 	github.com/go-audio/audio v1.0.0
 	github.com/go-audio/wav v1.1.0
@@ -11,6 +10,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/schollz/progressbar/v3 v3.11.0
 	github.com/speechly/api/go v0.0.0-20220920060221-2531f4783d08
+	github.com/speechly/nwalgo v0.0.0-20221109101309-d1a337619dd3
 	github.com/spf13/cobra v1.3.0
 	github.com/spf13/viper v1.10.0
 	golang.org/x/text v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -50,8 +50,6 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
-github.com/aebruno/nwalgo v0.0.0-20160817130739-4a232086e3ad h1:LyguZ2PuNuqBKHtslph/p+wuOwhYPtD9WcBELI14E0c=
-github.com/aebruno/nwalgo v0.0.0-20160817130739-4a232086e3ad/go.mod h1:saAZJO/REGx3bJzWCRoFi12bns5eE7y50iprbNdAunU=
 github.com/agnivade/levenshtein v1.1.1 h1:QY8M92nrzkmr798gCo3kmMyqXFzdQVpxLlGPRBij0P8=
 github.com/agnivade/levenshtein v1.1.1/go.mod h1:veldBMzWxcCG2ZvUTKD2kJNRdCk5hVbJomOvKkmgYbo=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -343,6 +341,8 @@ github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6Mwd
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/speechly/api/go v0.0.0-20220920060221-2531f4783d08 h1:zXbl+SvFylqwXwVGsPmu5SAcAU4axL03AYHE8qFQ+10=
 github.com/speechly/api/go v0.0.0-20220920060221-2531f4783d08/go.mod h1:KvNvGseEYbeNswC/9TA8LMQ0vPXGzcuWlY88N3x5V5Y=
+github.com/speechly/nwalgo v0.0.0-20221109101309-d1a337619dd3 h1:TdERud50FURQp3SUOiaYccbjK/9J5ZRjhVpU/oUsQfU=
+github.com/speechly/nwalgo v0.0.0-20221109101309-d1a337619dd3/go.mod h1:XNNsQ368L7ilmrdxJ9NgH+1GIOY3HbKf8xywk+9AJKQ=
 github.com/spf13/afero v1.3.3/go.mod h1:5KUK8ByomD5Ti5Artl0RtHeI5pTF7MIDuXL3yY520V4=
 github.com/spf13/afero v1.6.0 h1:xoax2sJ2DT8S8xA2paPFjDCScCNeWsg75VG0DLRreiY=
 github.com/spf13/afero v1.6.0/go.mod h1:Ai8FlHk4v/PARR026UzYexafAt9roJ7LcLMAmO6Z93I=

--- a/go.sum
+++ b/go.sum
@@ -50,6 +50,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+github.com/aebruno/nwalgo v0.0.0-20160817130739-4a232086e3ad h1:LyguZ2PuNuqBKHtslph/p+wuOwhYPtD9WcBELI14E0c=
+github.com/aebruno/nwalgo v0.0.0-20160817130739-4a232086e3ad/go.mod h1:saAZJO/REGx3bJzWCRoFi12bns5eE7y50iprbNdAunU=
 github.com/agnivade/levenshtein v1.1.1 h1:QY8M92nrzkmr798gCo3kmMyqXFzdQVpxLlGPRBij0P8=
 github.com/agnivade/levenshtein v1.1.1/go.mod h1:veldBMzWxcCG2ZvUTKD2kJNRdCk5hVbJomOvKkmgYbo=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -57,6 +59,7 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
+github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig+0+Ap1h4unLjW6YQJpKZVmUzxsD4E/Q=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
@@ -96,6 +99,7 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48 h1:fRzb/w+pyskVMQ+UbP35JkH8yB7MYb4q/qhBarqZE6g=
 github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48/go.mod h1:if7Fbed8SFyPtHLHbg49SI7NAdJiC5WIA09pe59rfAA=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=


### PR DESCRIPTION
- Update progress bar characters and width and clear it on finish
- Group both ASR and NLU output better
- Use our fork of [Needleman-Wunsch alignment](https://github.com/speechly/nwalgo) for ASR and NLU output. This is a rather simple tool that shows the where the ground truth and prediction differs.

**Progress bar**

```
Transcribing  50%  █████████▌░░░░░░░░░░  (2/4, 36 utt/min) [5s:3s]
```


**NLU output**

```
speechly evaluate nlu <app_id> test.txt

Line: 2
└─ Ground truth: *add_to_cart i want [two|2](amount) of those
└─ Prediction:   *add_to_cart i want *two*********** of those

Line: 4
└─ Ground truth: *set_delivery_date delivery [tomorrow|2022-01-*01](delivery_date)
└─ Prediction:   *set_delivery_date delivery [tomorrow|2022-11-10*](delivery_date)

Accuracy: 0.50 (2/4)
```

**ASR output**

```
speechly evaluate asr <app_id> test.jsonl 
                                                                  
Audio: podcast1.wav
└─ Ground truth: WELCOME TO ANOTHER EPISODE OF THE SPEECHLY PODCAST
└─ Prediction:   WELCOME TO ANOTHER EPISODE OF THE SPEECH** PODCAST

Audio: podcast3.wav
└─ Ground truth: THIS CONCEPT OF VOICE BEING AN EXPERT UI COULD YOU MAY***BE UNPACK THAT CONCEPT
└─ Prediction:   THIS CONCEPT OF VOICE BEING AN EXPERT UI COULD YOU MIGHT BE UNPACK THAT CONCEPT

Word Error Rate (WER): 0.04 (3/68)
```

**Known issues**

Long lines will wrap, but at least with these changes they are easier to distinguish. This PR does not try to make changes to that since it's a rabbit hole, believe me. I was in that hole for a brief moment of time before i managed to pull myself out of it...