### PR TITLE
Rewrite docs generation

### DIFF
--- a/cmd/annotate.go
+++ b/cmd/annotate.go
@@ -14,7 +14,7 @@ import (
 
 var annotateCmd = &cobra.Command{
 	Use:   "annotate",
-	Short: "Create SAL annotations for a list of examples using Speechly.",
+	Short: "Create SAL annotations for a list of examples using Speechly",
 	Long:  "To evaluate already deployed Speechly app, you need a set of evaluation examples that users of your application might say.",
 	Example: `speechly annotate input.txt <app_id>
 speechly annotate --app <app_id> --input input.txt > output.txt

--- a/cmd/annotate.go
+++ b/cmd/annotate.go
@@ -13,14 +13,13 @@ import (
 )
 
 var annotateCmd = &cobra.Command{
-	Use: "annotate [<input file>] [<app id>]",
-	Example: `speechly annotate -a <app_id> --input input.txt
-speechly annotate -a <app_id> --input input.txt > output.txt
-speechly annotate -a <app_id> --reference-date 2021-01-20 --input input.txt > output.txt
-
-To evaluate already deployed Speechly app, you need a set of evaluation examples that users of your application might say.`,
+	Use:   "annotate",
 	Short: "Create SAL annotations for a list of examples using Speechly.",
-	Args:  cobra.RangeArgs(0, 1),
+	Long:  "To evaluate already deployed Speechly app, you need a set of evaluation examples that users of your application might say.",
+	Example: `speechly annotate input.txt <app_id>
+speechly annotate --app <app_id> --input input.txt > output.txt
+speechly annotate --app <app_id> --reference-date 2021-01-20 --input input.txt > output.txt`,
+	Args: cobra.RangeArgs(0, 1),
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		appId, err := cmd.Flags().GetString("app")
 		if err != nil {
@@ -108,7 +107,7 @@ To evaluate already deployed Speechly app, you need a set of evaluation examples
 
 func init() {
 	RootCmd.AddCommand(annotateCmd)
-	annotateCmd.Flags().StringP("app", "a", "", "Application to evaluate. Can be given as the first positional argument.")
+	annotateCmd.Flags().StringP("app", "a", "", "Application to evaluate. Can be given as the second positional argument.")
 	annotateCmd.Flags().StringP("input", "i", "", "Evaluation utterances, separated by newline, if not provided, read from stdin. Can be given as the first positional argument.")
 	annotateCmd.Flags().StringP("output", "o", "", "Where to store annotated utterances, if not provided, print to stdout.")
 	annotateCmd.Flags().StringP("reference-date", "r", "", "Reference date in YYYY-MM-DD format, if not provided use current date.")

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -58,7 +58,7 @@ func waitForAppStatus(cmd *cobra.Command, configClient configv1.ConfigAPIClient,
 		if err != nil {
 			log.Fatalf("Failed to refresh app %s: %s", appId, err)
 		}
-		cmd.Printf("Status:\t%s", app.App.Status)
+		cmd.Printf("Status: %s", app.App.Status)
 		switch app.App.Status {
 		case configv1.App_STATUS_NEW:
 			cmd.Printf(", queued (%d jobs before this)", app.App.QueueSize)

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -15,7 +15,7 @@ import (
 
 var configCmd = &cobra.Command{
 	Use:     "projects [command]",
-	Aliases: []string{"config"},
+	Aliases: []string{"project", "config"},
 	Short:   "Manage API access to Speechly projects",
 	Args:    cobra.NoArgs,
 }
@@ -144,6 +144,7 @@ speechly projects add --apikey <api_token>`,
 
 var configRemoveCmd = &cobra.Command{
 	Use:     "remove",
+	Aliases: []string{"rm"},
 	Short:   "Remove access to a project",
 	Example: `speechly projects remove --name <project_name>`,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
@@ -174,8 +175,9 @@ var configRemoveCmd = &cobra.Command{
 }
 
 var configUseCmd = &cobra.Command{
-	Use:   "use",
-	Short: "Select the default project used",
+	Use:     "use",
+	Aliases: []string{"switch"},
+	Short:   "Select the default project used",
 	Example: `speechly projects use
 speechly projects use --name <project_name>`,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -27,11 +27,11 @@ func (u ConvertWriter) Write(data []byte) (n int, err error) {
 }
 
 var convertCmd = &cobra.Command{
-	Use: "convert [-l language] <input_file>",
-	Example: `speechly convert my-alexa-skill.json
-speechly convert -l en-US my-alexa-skill.json`,
+	Use:   "convert",
 	Short: "Converts an Alexa Interaction Model in JSON format to a Speechly configuration",
-	Args:  cobra.ExactArgs(1),
+	Example: `speechly convert my-alexa-skill.json
+speechly convert --language en-US my-alexa-skill.json`,
+	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := cmd.Context()
 		language, _ := cmd.Flags().GetString("language")

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -13,13 +13,12 @@ import (
 )
 
 var createCmd = &cobra.Command{
-	Use: "create [<application name>]",
-	Example: `speechly create "My App"
-speechly create --name "My App" --output-dir /foo/bar
-`,
+	Use:   "create",
 	Short: "Create a new application in the current project",
 	Long:  "Creates a new application in the current project and a config file in the current working directory.",
-	Args:  cobra.RangeArgs(0, 1),
+	Example: `speechly create "My App"
+speechly create --name "My App" --output-dir /foo/bar`,
+	Args: cobra.RangeArgs(0, 1),
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		name, _ := cmd.Flags().GetString("name")
 		if name == "" && len(args) == 0 {

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -14,9 +14,11 @@ import (
 )
 
 var deleteCmd = &cobra.Command{
-	Use:   "delete [<app_id>]",
+	Use:   "delete",
 	Short: "Delete an existing application",
-	Args:  cobra.RangeArgs(0, 1),
+	Example: `speechly delete <app_id>
+speechly delete --app <app_id> --force`,
+	Args: cobra.RangeArgs(0, 1),
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		appId, err := cmd.Flags().GetString("app")
 		if err != nil {

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -27,13 +27,12 @@ func (u DeployWriter) Write(data []byte) (n int, err error) {
 }
 
 var deployCmd = &cobra.Command{
-	Use: "deploy [<app_id>] <directory>",
-	Example: `speechly deploy <app_id> /path/to/config
-speechly deploy -a <app_id> .`,
+	Use:   "deploy",
 	Short: "Send the contents of a local directory to training",
-	Long: `The contents of the directory given as argument is sent to the
-API and validated. Then, a new model is trained and automatically deployed
-as the active model for the application.`,
+	Long:  "The contents of the directory given as argument is sent to the API and validated. Then, a new model is trained and automatically deployed as the active model for the application.",
+	Example: `speechly deploy <app_id> /path/to/config
+speechly deploy --app <app_id> .
+speechly deploy --watch --app <app_id> .`,
 	Args: cobra.RangeArgs(1, 2),
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		appId, _ := cmd.Flags().GetString("app")

--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -36,16 +36,16 @@ speechly describe --app <app_id>`,
 		if app.App.DeployedAtTime != nil {
 			deployedAt = app.App.DeployedAtTime.AsTime().String()
 		}
-		cmd.Printf("AppId:\t%s\n", app.App.Id)
-		cmd.Printf("Name:\t%s\n", app.App.Name)
-		cmd.Printf("Lang:\t%s\n", app.App.Language)
+		cmd.Printf("App ID: %s\n", app.App.Id)
+		cmd.Printf("Name: %s\n", app.App.Name)
+		cmd.Printf("Language: %s\n", app.App.Language)
 
 		waitFor := configv1.App_STATUS_UNSPECIFIED
 		if wait {
 			waitFor = configv1.App_STATUS_TRAINED
 		}
 		waitForAppStatus(cmd, configClient, appId, waitFor)
-		cmd.Printf("Deployed At:\t%s\n", deployedAt)
+		cmd.Printf("Deployed at: %s\n", deployedAt)
 	},
 }
 

--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -10,8 +10,10 @@ import (
 )
 
 var describeCmd = &cobra.Command{
-	Use:     "describe [<app_id>]",
-	Short:   "Print details about an application",
+	Use:   "describe",
+	Short: "Print details about an application",
+	Example: `speechly describe <app_id>
+speechly describe --app <app_id>`,
 	Args:    cobra.RangeArgs(0, 1),
 	PreRunE: checkSoleAppArgument,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -19,13 +19,12 @@ import (
 )
 
 var downloadCmd = &cobra.Command{
-	Use: "download [<app_id>] <directory> [flags]",
-	Example: `speechly download <app_id> /path/to/config
-speechly download -a <app_id> .
-speechly download -a <app_id> . --model tflite`,
+	Use:   "download",
 	Short: "Download the active configuration or model bundle of the given app.",
-	Long:  `Fetches the currently stored configuration or model bundle. This command does not check for validity of the stored configuration, but downloads the latest version.`,
-	Args:  cobra.RangeArgs(1, 2),
+	Long:  "Fetches the currently stored configuration or model bundle. This command does not check for validity of the stored configuration, but downloads the latest version.",
+	Example: `speechly download <app_id> /path/to/config
+speechly download --app <app_id> . --model tflite`,
+	Args: cobra.RangeArgs(1, 2),
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		appId, _ := cmd.Flags().GetString("app")
 		if appId == "" {

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -20,7 +20,7 @@ import (
 
 var downloadCmd = &cobra.Command{
 	Use:   "download",
-	Short: "Download the active configuration or model bundle of the given app.",
+	Short: "Download the active configuration or model bundle of the given app",
 	Long:  "Fetches the currently stored configuration or model bundle. This command does not check for validity of the stored configuration, but downloads the latest version.",
 	Example: `speechly download <app_id> /path/to/config
 speechly download --app <app_id> . --model tflite`,

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -12,6 +12,7 @@ import (
 var editCmd = &cobra.Command{
 	Use:   "edit",
 	Short: "Edit an existing application",
+	Example: `speechly edit --app <app_id> --name <new_name>`,
 	Run: func(cmd *cobra.Command, args []string) {
 		name, _ := cmd.Flags().GetString("name")
 

--- a/cmd/evaluate.go
+++ b/cmd/evaluate.go
@@ -10,13 +10,13 @@ import (
 
 var evaluateCmd = &cobra.Command{
 	Use:   "evaluate [command]",
-	Short: "Evaluate application model accuracy.",
+	Short: "Evaluate application model accuracy",
 	Args:  cobra.NoArgs,
 }
 
 var nluCmd = &cobra.Command{
 	Use:   "nlu",
-	Short: "Evaluate the NLU accuracy of the given application model.",
+	Short: "Evaluate the NLU accuracy of the given application model",
 	Long:  "To run NLU evaluation, you need a set of ground truth annotations. Use the `annotate` command to get started.",
 	Example: `speechly evaluate nlu <app_id> ground-truths.txt
 speechly evaluate nlu <app_id> ground-truths.txt --reference-date 2021-01-20`,
@@ -40,7 +40,7 @@ speechly evaluate nlu <app_id> ground-truths.txt --reference-date 2021-01-20`,
 
 var asrCmd = &cobra.Command{
 	Use:   "asr",
-	Short: "Evaluate the ASR accuracy of the given application model.",
+	Short: "Evaluate the ASR accuracy of the given application model",
 	Long:  "To run ASR evaluation, you need a set of ground truth transcripts. Use the `transcribe` command to get started.",
 	Example: `speechly evaluate asr <app_id> ground-truths.jsonl
 speechly evaluate asr <app_id> ground-truths.jsonl --streaming`,

--- a/cmd/evaluate.go
+++ b/cmd/evaluate.go
@@ -9,16 +9,18 @@ import (
 )
 
 var evaluateCmd = &cobra.Command{
-	Use:   "evaluate command [flags]",
+	Use:   "evaluate [command]",
 	Short: "Evaluate application model accuracy.",
 	Args:  cobra.NoArgs,
 }
 
 var nluCmd = &cobra.Command{
-	Use:     "nlu <app_id> <input_file>",
-	Example: `speechly evaluate nlu <app_id> annotated-utterances.txt`,
-	Short:   "Evaluate the NLU accuracy of the given application model.",
-	Args:    cobra.ExactArgs(2),
+	Use:   "nlu",
+	Short: "Evaluate the NLU accuracy of the given application model.",
+	Long:  "To run NLU evaluation, you need a set of ground truth annotations. Use the `annotate` command to get started.",
+	Example: `speechly evaluate nlu <app_id> ground-truths.txt
+speechly evaluate nlu <app_id> ground-truths.txt --reference-date 2021-01-20`,
+	Args: cobra.ExactArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := cmd.Context()
 		appID := args[0]
@@ -37,10 +39,12 @@ var nluCmd = &cobra.Command{
 }
 
 var asrCmd = &cobra.Command{
-	Use:     "asr <app_id> <input_file>",
-	Example: `speechly evaluate asr <app_id> utterances.jsonlines`,
-	Short:   "Evaluate the ASR accuracy of the given application model.",
-	Args:    cobra.ExactArgs(2),
+	Use:   "asr",
+	Short: "Evaluate the ASR accuracy of the given application model.",
+	Long:  "To run ASR evaluation, you need a set of ground truth transcripts. Use the `transcribe` command to get started.",
+	Example: `speechly evaluate asr <app_id> ground-truths.jsonl
+speechly evaluate asr <app_id> ground-truths.jsonl --streaming`,
+	Args: cobra.ExactArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := cmd.Context()
 		appID := args[0]

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -16,8 +16,9 @@ import (
 )
 
 var listCmd = &cobra.Command{
-	Use:   "list",
-	Short: "List applications in the current project",
+	Use:     "list",
+	Aliases: []string{"ls"},
+	Short:   "List applications in the current project",
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := cmd.Context()
 		configClient, err := clients.ConfigClient(ctx)

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -82,7 +82,7 @@ func printApps(out io.Writer, apps ...*configv1.App) error {
 	for _, app := range apps {
 		deployedAt := ""
 		if app.GetDeployedAtTime() != nil {
-			deployedAt = app.GetDeployedAtTime().AsTime().String()
+			deployedAt = app.GetDeployedAtTime().AsTime().Format("2006-01-02 15:04")
 		}
 		status := app.GetStatus().String()
 		if strings.Contains(status, "STATUS_") {

--- a/cmd/sample.go
+++ b/cmd/sample.go
@@ -34,13 +34,12 @@ func (u CompileWriter) Write(data []byte) (n int, err error) {
 }
 
 var sampleCmd = &cobra.Command{
-	Use: "sample [<app_id>] <directory>",
-	Example: `speechly sample -a <app_id> .
-speechly sample -a <app_id> /path/to/config
-speechly sample <app_id> /path/to/config --stats`,
+	Use:   "sample",
 	Short: "Sample a set of examples from the given SAL configuration",
-	Long: `The contents of the directory given as argument is sent to the
-API and compiled. If configuration is valid, a set of examples are printed to stdout.`,
+	Long:  "The contents of the directory given as argument is sent to the API and compiled. If configuration is valid, a set of examples are printed to stdout.",
+	Example: `speechly sample <app_id> .
+speechly sample --app <app_id> /path/to/config
+speechly sample <app_id> /path/to/config --stats`,
 	Args: cobra.RangeArgs(1, 2),
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		appId, _ := cmd.Flags().GetString("app")

--- a/cmd/stats.go
+++ b/cmd/stats.go
@@ -19,13 +19,13 @@ import (
 )
 
 var statsCmd = &cobra.Command{
-	Use: "stats [<app_id>]",
-	Example: `speechly stats [<app_id>]
-speechly stats -a APP_ID
+	Use:   "stats",
+	Short: "Get utterance statistics for the current project or an application in it",
+	Example: `speechly stats <app_id>
+speechly stats --app <app_id>
 speechly stats > output.csv
 speechly stats --start-date 2021-03-01 --end-date 2021-04-01`,
-	Short: "Get utterance statistics for the current project or an application in it",
-	Args:  cobra.RangeArgs(0, 1),
+	Args: cobra.RangeArgs(0, 1),
 	Run: func(cmd *cobra.Command, args []string) {
 		appId, err := cmd.Flags().GetString("app")
 		if err != nil {

--- a/cmd/transcribe.go
+++ b/cmd/transcribe.go
@@ -10,11 +10,13 @@ import (
 )
 
 var transcribeCmd = &cobra.Command{
-	Use: "transcribe <input_file>",
-	Example: `speechly transcribe <input_file> --model /path/to/model/bundle
-speechly transcribe <input_file> --app <app_id>`,
+	Use:   "transcribe",
 	Short: "Transcribe the given file(s) using on-device or cloud transcription",
-	Args:  cobra.RangeArgs(1, 1),
+	Long:  "To transcribe multiple files, create a JSON Lines file with each audio on their own line using the format `{\"audio\":\"/path/to/file\"}`.",
+	Example: `speechly transcribe file.wav --app <app_id>
+speechly transcribe files.jsonl --app <app_id> > output.jsonl
+speechly transcribe files.jsonl --model /path/to/model/bundle`,
+	Args: cobra.RangeArgs(1, 1),
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := cmd.Context()
 		model, err := cmd.Flags().GetString("model")

--- a/cmd/utterances.go
+++ b/cmd/utterances.go
@@ -12,7 +12,7 @@ import (
 
 var utterancesCmd = &cobra.Command{
 	Use:     "utterances",
-	Short:   "Get a sample of recent utterances.",
+	Short:   "Get a sample of recent utterances",
 	Long:    "Fetches a sample of recent utterances and their SAL-annotated transcript.",
 	Example: `speechly utterances <app_id>`,
 	Args:    cobra.ExactArgs(1),

--- a/cmd/utterances.go
+++ b/cmd/utterances.go
@@ -11,10 +11,11 @@ import (
 )
 
 var utterancesCmd = &cobra.Command{
-	Use:   "utterances <app_id>",
-	Short: "Get a sample of recent utterances.",
-	Long:  `Fetches a sample of recent utterances and their SAL-annotated transcript.`,
-	Args:  cobra.ExactArgs(1),
+	Use:     "utterances",
+	Short:   "Get a sample of recent utterances.",
+	Long:    "Fetches a sample of recent utterances and their SAL-annotated transcript.",
+	Example: `speechly utterances <app_id>`,
+	Args:    cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := cmd.Context()
 		appId := args[0]

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -28,13 +28,12 @@ func (u ValidateWriter) Write(data []byte) (n int, err error) {
 }
 
 var validateCmd = &cobra.Command{
-	Use: "validate [<app_id>] <directory>",
-	Example: `speechly validate -a <app_id> .
-speechly validate <app_id> /path/to/config`,
+	Use: "validate",
+	Example: `speechly validate <app_id> .
+speechly validate --app <app_id> /path/to/config`,
 	Short: "Validate the given configuration for syntax errors",
-	Long: `The contents of the directory given as argument is sent to the
-API and validated. Possible errors are printed to stdout.`,
-	Args: cobra.RangeArgs(1, 2),
+	Long:  "The contents of the directory given as argument is sent to the API and validated. Possible errors are printed to stdout.",
+	Args:  cobra.RangeArgs(1, 2),
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		appId, _ := cmd.Flags().GetString("app")
 		if appId == "" {

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,41 +1,94 @@
-# speechly
+# Available commands
 
-Speechly CLI
+#### [`annotate`](annotate.md)
 
-## Synopsis
+Create SAL annotations for a list of examples using Speechly.
 
+#### [`convert`](convert.md)
 
-███████╗██████╗ ███████╗███████╗ ██████╗██╗  ██╗██╗  ██╗   ██╗
-██╔════╝██╔══██╗██╔════╝██╔════╝██╔════╝██║  ██║██║  ╚██╗ ██╔╝
-███████╗██████╔╝█████╗  █████╗  ██║     ███████║██║   ╚████╔╝
-╚════██║██╔═══╝ ██╔══╝  ██╔══╝  ██║     ██╔══██║██║    ╚██╔╝
-███████║██║     ███████╗███████╗╚██████╗██║  ██║███████╗██║
-╚══════╝╚═╝     ╚══════╝╚══════╝ ╚═════╝╚═╝  ╚═╝╚══════╝╚═╝
+Converts an Alexa Interaction Model in JSON format to a Speechly configuration
 
+#### [`create`](create.md)
 
-## Options
+Create a new application in the current project
 
-```
-  -h, --help   help for speechly
-```
+#### [`delete`](delete.md)
 
-## See also
+Delete an existing application
 
-* [annotate](annotate.md)	 - Create SAL annotations for a list of examples using Speechly.
-* [convert](convert.md)	 - Converts an Alexa Interaction Model in JSON format to a Speechly configuration
-* [create](create.md)	 - Create a new application in the current project
-* [delete](delete.md)	 - Delete an existing application
-* [deploy](deploy.md)	 - Send the contents of a local directory to training
-* [describe](describe.md)	 - Print details about an application
-* [download](download.md)	 - Download the active configuration or model bundle of the given app.
-* [edit](edit.md)	 - Edit an existing application
-* [evaluate](evaluate.md)	 - Evaluate application model accuracy.
-* [list](list.md)	 - List applications in the current project
-* [projects](projects.md)	 - Manage API access to Speechly projects
-* [sample](sample.md)	 - Sample a set of examples from the given SAL configuration
-* [stats](stats.md)	 - Get utterance statistics for the current project or an application in it
-* [transcribe](transcribe.md)	 - Transcribe the given file(s) using on-device or cloud transcription
-* [utterances](utterances.md)	 - Get a sample of recent utterances.
-* [validate](validate.md)	 - Validate the given configuration for syntax errors
-* [version](version.md)	 - Print the version number
+#### [`deploy`](deploy.md)
+
+Send the contents of a local directory to training
+
+#### [`describe`](describe.md)
+
+Print details about an application
+
+#### [`download`](download.md)
+
+Download the active configuration or model bundle of the given app.
+
+#### [`edit`](edit.md)
+
+Edit an existing application
+
+#### [`evaluate`](evaluate.md)
+
+Evaluate application model accuracy.
+
+#### [`evaluate asr`](evaluate_asr.md)
+
+Evaluate the ASR accuracy of the given application model.
+
+#### [`evaluate nlu`](evaluate_nlu.md)
+
+Evaluate the NLU accuracy of the given application model.
+
+#### [`list`](list.md)
+
+List applications in the current project
+
+#### [`projects`](projects.md)
+
+Manage API access to Speechly projects
+
+#### [`projects add`](projects_add.md)
+
+Add access to a pre-existing project
+
+#### [`projects list`](projects_list.md)
+
+List known projects
+
+#### [`projects remove`](projects_remove.md)
+
+Remove access to a project
+
+#### [`projects use`](projects_use.md)
+
+Select the default project used
+
+#### [`sample`](sample.md)
+
+Sample a set of examples from the given SAL configuration
+
+#### [`stats`](stats.md)
+
+Get utterance statistics for the current project or an application in it
+
+#### [`transcribe`](transcribe.md)
+
+Transcribe the given file(s) using on-device or cloud transcription
+
+#### [`utterances`](utterances.md)
+
+Get a sample of recent utterances.
+
+#### [`validate`](validate.md)
+
+Validate the given configuration for syntax errors
+
+#### [`version`](version.md)
+
+Print the version number
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 #### [`annotate`](annotate.md)
 
-Create SAL annotations for a list of examples using Speechly.
+Create SAL annotations for a list of examples using Speechly
 
 #### [`convert`](convert.md)
 
@@ -26,7 +26,7 @@ Print details about an application
 
 #### [`download`](download.md)
 
-Download the active configuration or model bundle of the given app.
+Download the active configuration or model bundle of the given app
 
 #### [`edit`](edit.md)
 
@@ -34,15 +34,15 @@ Edit an existing application
 
 #### [`evaluate`](evaluate.md)
 
-Evaluate application model accuracy.
+Evaluate application model accuracy
 
 #### [`evaluate asr`](evaluate_asr.md)
 
-Evaluate the ASR accuracy of the given application model.
+Evaluate the ASR accuracy of the given application model
 
 #### [`evaluate nlu`](evaluate_nlu.md)
 
-Evaluate the NLU accuracy of the given application model.
+Evaluate the NLU accuracy of the given application model
 
 #### [`list`](list.md)
 
@@ -82,7 +82,7 @@ Transcribe the given file(s) using on-device or cloud transcription
 
 #### [`utterances`](utterances.md)
 
-Get a sample of recent utterances.
+Get a sample of recent utterances
 
 #### [`validate`](validate.md)
 

--- a/docs/annotate.md
+++ b/docs/annotate.md
@@ -1,6 +1,6 @@
 # annotate
 
-Create SAL annotations for a list of examples using Speechly.
+Create SAL annotations for a list of examples using Speechly
 
 ### Usage
 

--- a/docs/annotate.md
+++ b/docs/annotate.md
@@ -2,33 +2,28 @@
 
 Create SAL annotations for a list of examples using Speechly.
 
-```
-speechly annotate [<input file>] [<app id>] [flags]
-```
-
-## Examples
+### Usage
 
 ```
-speechly annotate -a <app_id> --input input.txt
-speechly annotate -a <app_id> --input input.txt > output.txt
-speechly annotate -a <app_id> --reference-date 2021-01-20 --input input.txt > output.txt
+speechly annotate [flags]
+```
 
 To evaluate already deployed Speechly app, you need a set of evaluation examples that users of your application might say.
+
+### Flags
+
+* `--app` `-a` _(string)_ - Application to evaluate. Can be given as the second positional argument.
+* `--de-annotate` `-d` _(bool)_ - Instead of adding annotation, remove annotations from output.
+* `--evaluate` `-e` _(bool)_ - Print evaluation stats instead of the annotated output.
+* `--help` `-h` _(bool)_ - help for annotate
+* `--input` `-i` _(string)_ - Evaluation utterances, separated by newline, if not provided, read from stdin. Can be given as the first positional argument.
+* `--output` `-o` _(string)_ - Where to store annotated utterances, if not provided, print to stdout.
+* `--reference-date` `-r` _(string)_ - Reference date in YYYY-MM-DD format, if not provided use current date.
+
+### Examples
+
 ```
-
-## Options
-
+speechly annotate input.txt <app_id>
+speechly annotate --app <app_id> --input input.txt > output.txt
+speechly annotate --app <app_id> --reference-date 2021-01-20 --input input.txt > output.txt
 ```
-  -a, --app string              Application to evaluate. Can be given as the first positional argument.
-  -d, --de-annotate             Instead of adding annotation, remove annotations from output.
-  -e, --evaluate                Print evaluation stats instead of the annotated output.
-  -h, --help                    help for annotate
-  -i, --input string            Evaluation utterances, separated by newline, if not provided, read from stdin. Can be given as the first positional argument.
-  -o, --output string           Where to store annotated utterances, if not provided, print to stdout.
-  -r, --reference-date string   Reference date in YYYY-MM-DD format, if not provided use current date.
-```
-
-## See also
-
-* [speechly](README.md)	 - Speechly CLI
-

--- a/docs/convert.md
+++ b/docs/convert.md
@@ -2,25 +2,20 @@
 
 Converts an Alexa Interaction Model in JSON format to a Speechly configuration
 
+### Usage
+
 ```
-speechly convert [-l language] <input_file> [flags]
+speechly convert [flags]
 ```
 
-## Examples
+### Flags
+
+* `--help` `-h` _(bool)_ - help for convert
+* `--language` `-l` _(string)_ - Language of input
+
+### Examples
 
 ```
 speechly convert my-alexa-skill.json
-speechly convert -l en-US my-alexa-skill.json
+speechly convert --language en-US my-alexa-skill.json
 ```
-
-## Options
-
-```
-  -h, --help              help for convert
-  -l, --language string   Language of input (default "en-US")
-```
-
-## See also
-
-* [speechly](README.md)	 - Speechly CLI
-

--- a/docs/create.md
+++ b/docs/create.md
@@ -2,32 +2,24 @@
 
 Create a new application in the current project
 
-## Synopsis
+### Usage
+
+```
+speechly create [flags]
+```
 
 Creates a new application in the current project and a config file in the current working directory.
 
-```
-speechly create [<application name>] [flags]
-```
+### Flags
 
-## Examples
+* `--help` `-h` _(bool)_ - help for create
+* `--language` `-l` _(string)_ - Application language. Available options are 'en-US' and 'fi-FI'.
+* `--name` `-n` _(string)_ - Application name. Can be given as the sole positional argument.
+* `--output-dir` `-o` _(string)_ - Output directory for the config file.
+
+### Examples
 
 ```
 speechly create "My App"
 speechly create --name "My App" --output-dir /foo/bar
-
 ```
-
-## Options
-
-```
-  -h, --help                help for create
-  -l, --language string     Application language. Available options are 'en-US' and 'fi-FI'. (default "en-US")
-  -n, --name string         Application name. Can be given as the sole positional argument.
-  -o, --output-dir string   Output directory for the config file.
-```
-
-## See also
-
-* [speechly](README.md)	 - Speechly CLI
-

--- a/docs/delete.md
+++ b/docs/delete.md
@@ -2,20 +2,22 @@
 
 Delete an existing application
 
-```
-speechly delete [<app_id>] [flags]
-```
-
-## Options
+### Usage
 
 ```
-  -a, --app string   Application to delete. Can be given as the sole positional argument.
-  -d, --dry-run      Don't perform the deletion.
-  -f, --force        Skip confirmation prompt.
-  -h, --help         help for delete
+speechly delete [flags]
 ```
 
-## See also
+### Flags
 
-* [speechly](README.md)	 - Speechly CLI
+* `--app` `-a` _(string)_ - Application to delete. Can be given as the sole positional argument.
+* `--dry-run` `-d` _(bool)_ - Don't perform the deletion.
+* `--force` `-f` _(bool)_ - Skip confirmation prompt.
+* `--help` `-h` _(bool)_ - help for delete
 
+### Examples
+
+```
+speechly delete <app_id>
+speechly delete --app <app_id> --force
+```

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -2,33 +2,25 @@
 
 Send the contents of a local directory to training
 
-## Synopsis
-
-The contents of the directory given as argument is sent to the
-API and validated. Then, a new model is trained and automatically deployed
-as the active model for the application.
+### Usage
 
 ```
-speechly deploy [<app_id>] <directory> [flags]
+speechly deploy [flags]
 ```
 
-## Examples
+The contents of the directory given as argument is sent to the API and validated. Then, a new model is trained and automatically deployed as the active model for the application.
+
+### Flags
+
+* `--app` `-a` _(string)_ - Application to deploy the files to. Can be given as the first positional argument.
+* `--help` `-h` _(bool)_ - help for deploy
+* `--skip-validation` _(bool)_ - Skip the validation step. If there are validation issues, they will not be shown, the deploy will fail silently.
+* `--watch` `-w` _(bool)_ - Wait for training to be finished.
+
+### Examples
 
 ```
 speechly deploy <app_id> /path/to/config
-speechly deploy -a <app_id> .
+speechly deploy --app <app_id> .
+speechly deploy --watch --app <app_id> .
 ```
-
-## Options
-
-```
-  -a, --app string        Application to deploy the files to. Can be given as the first positional argument.
-  -h, --help              help for deploy
-      --skip-validation   Skip the validation step. If there are validation issues, they will not be shown, the deploy will fail silently.
-  -w, --watch             Wait for training to be finished.
-```
-
-## See also
-
-* [speechly](README.md)	 - Speechly CLI
-

--- a/docs/describe.md
+++ b/docs/describe.md
@@ -2,19 +2,21 @@
 
 Print details about an application
 
-```
-speechly describe [<app_id>] [flags]
-```
-
-## Options
+### Usage
 
 ```
-  -a, --app string   Application to describe. Can be given as the sole positional argument.
-  -h, --help         help for describe
-  -w, --watch        If app status is training, wait until it is finished.
+speechly describe [flags]
 ```
 
-## See also
+### Flags
 
-* [speechly](README.md)	 - Speechly CLI
+* `--app` `-a` _(string)_ - Application to describe. Can be given as the sole positional argument.
+* `--help` `-h` _(bool)_ - help for describe
+* `--watch` `-w` _(bool)_ - If app status is training, wait until it is finished.
 
+### Examples
+
+```
+speechly describe <app_id>
+speechly describe --app <app_id>
+```

--- a/docs/download.md
+++ b/docs/download.md
@@ -2,31 +2,23 @@
 
 Download the active configuration or model bundle of the given app.
 
-## Synopsis
+### Usage
+
+```
+speechly download [flags]
+```
 
 Fetches the currently stored configuration or model bundle. This command does not check for validity of the stored configuration, but downloads the latest version.
 
-```
-speechly download [<app_id>] <directory> [flags]
-```
+### Flags
 
-## Examples
+* `--app` `-a` _(string)_ - Application which configuration or model bundle to download. Can be given as the first positional argument.
+* `--help` `-h` _(bool)_ - help for download
+* `--model` `-m` _(string)_ - Model bundle machine learning framework. Available options are: ort, tflite, coreml and all. This feature is available on Enterprise plans (https://speechly.com/pricing)
+
+### Examples
 
 ```
 speechly download <app_id> /path/to/config
-speechly download -a <app_id> .
-speechly download -a <app_id> . --model tflite
+speechly download --app <app_id> . --model tflite
 ```
-
-## Options
-
-```
-  -a, --app string     Application which configuration or model bundle to download. Can be given as the first positional argument.
-  -h, --help           help for download
-  -m, --model string   Model bundle machine learning framework. Available options are: ort, tflite, coreml and all. This feature is available on Enterprise plans (https://speechly.com/pricing)
-```
-
-## See also
-
-* [speechly](README.md)	 - Speechly CLI
-

--- a/docs/download.md
+++ b/docs/download.md
@@ -1,6 +1,6 @@
 # download
 
-Download the active configuration or model bundle of the given app.
+Download the active configuration or model bundle of the given app
 
 ### Usage
 

--- a/docs/edit.md
+++ b/docs/edit.md
@@ -2,19 +2,20 @@
 
 Edit an existing application
 
+### Usage
+
 ```
 speechly edit [flags]
 ```
 
-## Options
+### Flags
+
+* `--app` `-a` _(string)_ - Application to edit
+* `--help` `-h` _(bool)_ - help for edit
+* `--name` `-n` _(string)_ - Application name
+
+### Examples
 
 ```
-  -a, --app string    Application to edit
-  -h, --help          help for edit
-  -n, --name string   Application name
+speechly edit --app <app_id> --name <new_name>
 ```
-
-## See also
-
-* [speechly](README.md)	 - Speechly CLI
-

--- a/docs/evaluate.md
+++ b/docs/evaluate.md
@@ -1,6 +1,6 @@
 # evaluate
 
-Evaluate application model accuracy.
+Evaluate application model accuracy
 
 ### Usage
 
@@ -10,8 +10,8 @@ speechly evaluate [command] [flags]
 
 ### Subcommands
 
-* [`evaluate asr`](evaluate_asr.md) - Evaluate the ASR accuracy of the given application model.
-* [`evaluate nlu`](evaluate_nlu.md) - Evaluate the NLU accuracy of the given application model.
+* [`evaluate asr`](evaluate_asr.md) - Evaluate the ASR accuracy of the given application model
+* [`evaluate nlu`](evaluate_nlu.md) - Evaluate the NLU accuracy of the given application model
 
 ### Flags
 

--- a/docs/evaluate.md
+++ b/docs/evaluate.md
@@ -2,15 +2,17 @@
 
 Evaluate application model accuracy.
 
-## Options
+### Usage
 
 ```
-  -h, --help   help for evaluate
+speechly evaluate [command] [flags]
 ```
 
-## See also
+### Subcommands
 
-* [speechly](README.md)	 - Speechly CLI
-* [evaluate asr](evaluate_asr.md)	 - Evaluate the ASR accuracy of the given application model.
-* [evaluate nlu](evaluate_nlu.md)	 - Evaluate the NLU accuracy of the given application model.
+* [`evaluate asr`](evaluate_asr.md) - Evaluate the ASR accuracy of the given application model.
+* [`evaluate nlu`](evaluate_nlu.md) - Evaluate the NLU accuracy of the given application model.
 
+### Flags
+
+* `--help` `-h` _(bool)_ - help for evaluate

--- a/docs/evaluate_asr.md
+++ b/docs/evaluate_asr.md
@@ -2,24 +2,22 @@
 
 Evaluate the ASR accuracy of the given application model.
 
-```
-speechly evaluate asr <app_id> <input_file> [flags]
-```
-
-## Examples
+### Usage
 
 ```
-speechly evaluate asr <app_id> utterances.jsonlines
+speechly evaluate asr [flags]
 ```
 
-## Options
+To run ASR evaluation, you need a set of ground truth transcripts. Use the `transcribe` command to get started.
+
+### Flags
+
+* `--help` `-h` _(bool)_ - help for asr
+* `--streaming` _(bool)_ - Use the Streaming API instead of the Batch API.
+
+### Examples
 
 ```
-  -h, --help        help for asr
-      --streaming   Use the Streaming API instead of the Batch API.
+speechly evaluate asr <app_id> ground-truths.jsonl
+speechly evaluate asr <app_id> ground-truths.jsonl --streaming
 ```
-
-## See also
-
-* [evaluate](evaluate.md)	 - Evaluate application model accuracy.
-

--- a/docs/evaluate_asr.md
+++ b/docs/evaluate_asr.md
@@ -1,6 +1,6 @@
 # evaluate asr
 
-Evaluate the ASR accuracy of the given application model.
+Evaluate the ASR accuracy of the given application model
 
 ### Usage
 

--- a/docs/evaluate_nlu.md
+++ b/docs/evaluate_nlu.md
@@ -2,24 +2,22 @@
 
 Evaluate the NLU accuracy of the given application model.
 
-```
-speechly evaluate nlu <app_id> <input_file> [flags]
-```
-
-## Examples
+### Usage
 
 ```
-speechly evaluate nlu <app_id> annotated-utterances.txt
+speechly evaluate nlu [flags]
 ```
 
-## Options
+To run NLU evaluation, you need a set of ground truth annotations. Use the `annotate` command to get started.
+
+### Flags
+
+* `--help` `-h` _(bool)_ - help for nlu
+* `--reference-date` `-r` _(string)_ - Reference date in YYYY-MM-DD format, if not provided use current date.
+
+### Examples
 
 ```
-  -h, --help                    help for nlu
-  -r, --reference-date string   Reference date in YYYY-MM-DD format, if not provided use current date.
+speechly evaluate nlu <app_id> ground-truths.txt
+speechly evaluate nlu <app_id> ground-truths.txt --reference-date 2021-01-20
 ```
-
-## See also
-
-* [evaluate](evaluate.md)	 - Evaluate application model accuracy.
-

--- a/docs/evaluate_nlu.md
+++ b/docs/evaluate_nlu.md
@@ -1,6 +1,6 @@
 # evaluate nlu
 
-Evaluate the NLU accuracy of the given application model.
+Evaluate the NLU accuracy of the given application model
 
 ### Usage
 

--- a/docs/generate.go
+++ b/docs/generate.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
@@ -101,6 +102,11 @@ func header(c *cobra.Command) string {
 
 	if c.Long != "" {
 		b.WriteString(c.Long + "\n\n")
+	}
+
+	if c.Aliases != nil {
+		a := fmt.Sprintf("%v", strings.Join(c.Aliases, ", "))
+		b.WriteString(fmt.Sprintf("Command aliases: `%s`\n\n", a))
 	}
 
 	return b.String()

--- a/docs/list.md
+++ b/docs/list.md
@@ -8,6 +8,8 @@ List applications in the current project
 speechly list [flags]
 ```
 
+Command aliases: `ls`
+
 ### Flags
 
 * `--help` `-h` _(bool)_ - help for list

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -2,20 +2,19 @@
 
 Manage API access to Speechly projects
 
-```
-speechly projects [flags]
-```
-
-## Options
+### Usage
 
 ```
-  -h, --help   help for projects
+speechly projects [command] [flags]
 ```
 
-## See also
+### Subcommands
 
-* [speechly](README.md)	 - Speechly CLI
-* [projects add](projects_add.md)	 - Add access to a pre-existing project
-* [projects remove](projects_remove.md)	 - Remove access to a project
-* [projects use](projects_use.md)	 - Select the default project used
+* [`projects add`](projects_add.md) - Add access to a pre-existing project
+* [`projects list`](projects_list.md) - List known projects
+* [`projects remove`](projects_remove.md) - Remove access to a project
+* [`projects use`](projects_use.md) - Select the default project used
 
+### Flags
+
+* `--help` `-h` _(bool)_ - help for projects

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -8,6 +8,8 @@ Manage API access to Speechly projects
 speechly projects [command] [flags]
 ```
 
+Command aliases: `project, config`
+
 ### Subcommands
 
 * [`projects add`](projects_add.md) - Add access to a pre-existing project

--- a/docs/projects_add.md
+++ b/docs/projects_add.md
@@ -2,21 +2,23 @@
 
 Add access to a pre-existing project
 
-```
-speechly projects add [apikey] [flags]
-```
-
-## Options
+### Usage
 
 ```
-      --apikey string            API token, created in Speechly Dashboard. Can also be given as the sole positional argument.
-  -h, --help                     help for add
-      --host string              API address (default "api.speechly.com")
-      --name string              An unique name for the project. If not given the project name configured in Speechly Dashboard will be used.
-      --skip-online-validation   Skips validating the API token against the host.
+speechly projects add [flags]
 ```
 
-## See also
+### Flags
 
-* [projects](projects.md)	 - Manage API access to Speechly projects
+* `--apikey` _(string)_ - API token, created in Speechly Dashboard. Can also be given as the sole positional argument.
+* `--help` `-h` _(bool)_ - help for add
+* `--host` _(string)_ - API address
+* `--name` _(string)_ - An unique name for the project. If not given the project name configured in Speechly Dashboard will be used.
+* `--skip-online-validation` _(bool)_ - Skips validating the API token against the host.
 
+### Examples
+
+```
+speechly projects add <api_token>
+speechly projects add --apikey <api_token>
+```

--- a/docs/projects_list.md
+++ b/docs/projects_list.md
@@ -8,6 +8,8 @@ List known projects
 speechly projects list [flags]
 ```
 
+Command aliases: `ls`
+
 ### Flags
 
 * `--help` `-h` _(bool)_ - help for list

--- a/docs/projects_list.md
+++ b/docs/projects_list.md
@@ -1,11 +1,11 @@
-# list
+# projects list
 
-List applications in the current project
+List known projects
 
 ### Usage
 
 ```
-speechly list [flags]
+speechly projects list [flags]
 ```
 
 ### Flags

--- a/docs/projects_remove.md
+++ b/docs/projects_remove.md
@@ -8,6 +8,8 @@ Remove access to a project
 speechly projects remove [flags]
 ```
 
+Command aliases: `rm`
+
 ### Flags
 
 * `--help` `-h` _(bool)_ - help for remove

--- a/docs/projects_remove.md
+++ b/docs/projects_remove.md
@@ -2,18 +2,19 @@
 
 Remove access to a project
 
+### Usage
+
 ```
 speechly projects remove [flags]
 ```
 
-## Options
+### Flags
+
+* `--help` `-h` _(bool)_ - help for remove
+* `--name` _(string)_ - The name for the project for which access is to be removed.
+
+### Examples
 
 ```
-  -h, --help          help for remove
-      --name string   The name for the project for which access is to be removed.
+speechly projects remove --name <project_name>
 ```
-
-## See also
-
-* [projects](projects.md)	 - Manage API access to Speechly projects
-

--- a/docs/projects_use.md
+++ b/docs/projects_use.md
@@ -8,6 +8,8 @@ Select the default project used
 speechly projects use [flags]
 ```
 
+Command aliases: `switch`
+
 ### Flags
 
 * `--help` `-h` _(bool)_ - help for use

--- a/docs/projects_use.md
+++ b/docs/projects_use.md
@@ -2,18 +2,20 @@
 
 Select the default project used
 
+### Usage
+
 ```
 speechly projects use [flags]
 ```
 
-## Options
+### Flags
+
+* `--help` `-h` _(bool)_ - help for use
+* `--name` _(string)_ - An unique name for the project.
+
+### Examples
 
 ```
-  -h, --help          help for use
-      --name string   An unique name for the project.
+speechly projects use
+speechly projects use --name <project_name>
 ```
-
-## See also
-
-* [projects](projects.md)	 - Manage API access to Speechly projects
-

--- a/docs/sample.md
+++ b/docs/sample.md
@@ -2,36 +2,28 @@
 
 Sample a set of examples from the given SAL configuration
 
-## Synopsis
-
-The contents of the directory given as argument is sent to the
-API and compiled. If configuration is valid, a set of examples are printed to stdout.
+### Usage
 
 ```
-speechly sample [<app_id>] <directory> [flags]
+speechly sample [flags]
 ```
 
-## Examples
+The contents of the directory given as argument is sent to the API and compiled. If configuration is valid, a set of examples are printed to stdout.
+
+### Flags
+
+* `--app` `-a` _(string)_ - Application to sample the files from. Can be given as the first positional argument.
+* `--batch-size` _(int)_ - How many examples to return. Must be between 32 and 10000.
+* `--seed` _(int)_ - Random seed to use when initializing the sampler.
+* `--stats` _(bool)_ - Print intent and entity distributions to the output.
+* `--advanced-stats` _(bool)_ - Print entity type, value and value pair distributions to the output.
+* `--advanced-stats-limit` _(int)_ - Line limit for advanced_stats. The lines are ordered by count.
+* `--help` `-h` _(bool)_ - help for sample
+
+### Examples
 
 ```
-speechly sample -a <app_id> .
-speechly sample -a <app_id> /path/to/config
+speechly sample <app_id> .
+speechly sample --app <app_id> /path/to/config
 speechly sample <app_id> /path/to/config --stats
 ```
-
-## Options
-
-```
-  -a, --app string                 Application to sample the files from. Can be given as the first positional argument.
-      --batch-size int             How many examples to return. Must be between 32 and 10000. (default 100)
-      --seed int                   Random seed to use when initializing the sampler.
-      --stats                      Print intent and entity distributions to the output.
-      --advanced-stats             Print entity type, value and value pair distributions to the output.
-      --advanced-stats-limit int   Line limit for advanced_stats. The lines are ordered by count. (default 10)
-  -h, --help                       help for sample
-```
-
-## See also
-
-* [speechly](README.md)	 - Speechly CLI
-

--- a/docs/stats.md
+++ b/docs/stats.md
@@ -2,30 +2,25 @@
 
 Get utterance statistics for the current project or an application in it
 
-```
-speechly stats [<app_id>] [flags]
-```
-
-## Examples
+### Usage
 
 ```
-speechly stats [<app_id>]
-speechly stats -a APP_ID
+speechly stats [flags]
+```
+
+### Flags
+
+* `--app` `-a` _(string)_ - Application to get the statistics for. Can be given as the sole positional argument.
+* `--end-date` _(string)_ - End date for statistics, not included in results.
+* `--export` _(bool)_ - Print report as CSV
+* `--help` `-h` _(bool)_ - help for stats
+* `--start-date` _(string)_ - Start date for statistics.
+
+### Examples
+
+```
+speechly stats <app_id>
+speechly stats --app <app_id>
 speechly stats > output.csv
 speechly stats --start-date 2021-03-01 --end-date 2021-04-01
 ```
-
-## Options
-
-```
-  -a, --app string          Application to get the statistics for. Can be given as the sole positional argument.
-      --end-date string     End date for statistics, not included in results.
-      --export              Print report as CSV
-  -h, --help                help for stats
-      --start-date string   Start date for statistics.
-```
-
-## See also
-
-* [speechly](README.md)	 - Speechly CLI
-

--- a/docs/transcribe.md
+++ b/docs/transcribe.md
@@ -2,27 +2,25 @@
 
 Transcribe the given file(s) using on-device or cloud transcription
 
-```
-speechly transcribe <input_file> [flags]
-```
-
-## Examples
+### Usage
 
 ```
-speechly transcribe <input_file> --model /path/to/model/bundle
-speechly transcribe <input_file> --app <app_id>
+speechly transcribe [flags]
 ```
 
-## Options
+To transcribe multiple files, create a JSON Lines file with each audio on their own line using the format `{"audio":"/path/to/file"}`.
+
+### Flags
+
+* `--app` `-a` _(string)_ - Application ID to use for cloud transcription
+* `--help` `-h` _(bool)_ - help for transcribe
+* `--model` `-m` _(string)_ - Model bundle file. This feature is available on Enterprise plans (https://speechly.com/pricing)
+* `--streaming` _(bool)_ - Use the Streaming API instead of the Batch API.
+
+### Examples
 
 ```
-  -a, --app string     Application ID to use for cloud transcription
-  -h, --help           help for transcribe
-  -m, --model string   Model bundle file. This feature is available on Enterprise plans (https://speechly.com/pricing)
-      --streaming      Use the Streaming API instead of the Batch API.
+speechly transcribe file.wav --app <app_id>
+speechly transcribe files.jsonl --app <app_id> > output.jsonl
+speechly transcribe files.jsonl --model /path/to/model/bundle
 ```
-
-## See also
-
-* [speechly](README.md)	 - Speechly CLI
-

--- a/docs/utterances.md
+++ b/docs/utterances.md
@@ -1,6 +1,6 @@
 # utterances
 
-Get a sample of recent utterances.
+Get a sample of recent utterances
 
 ### Usage
 

--- a/docs/utterances.md
+++ b/docs/utterances.md
@@ -2,21 +2,20 @@
 
 Get a sample of recent utterances.
 
-## Synopsis
+### Usage
+
+```
+speechly utterances [flags]
+```
 
 Fetches a sample of recent utterances and their SAL-annotated transcript.
 
+### Flags
+
+* `--help` `-h` _(bool)_ - help for utterances
+
+### Examples
+
 ```
-speechly utterances <app_id> [flags]
+speechly utterances <app_id>
 ```
-
-## Options
-
-```
-  -h, --help   help for utterances
-```
-
-## See also
-
-* [speechly](README.md)	 - Speechly CLI
-

--- a/docs/validate.md
+++ b/docs/validate.md
@@ -2,30 +2,22 @@
 
 Validate the given configuration for syntax errors
 
-## Synopsis
-
-The contents of the directory given as argument is sent to the
-API and validated. Possible errors are printed to stdout.
+### Usage
 
 ```
-speechly validate [<app_id>] <directory> [flags]
+speechly validate [flags]
 ```
 
-## Examples
+The contents of the directory given as argument is sent to the API and validated. Possible errors are printed to stdout.
+
+### Flags
+
+* `--app` `-a` _(string)_ - Application to validate the files for. Can be given as the first positional argument.
+* `--help` `-h` _(bool)_ - help for validate
+
+### Examples
 
 ```
-speechly validate -a <app_id> .
-speechly validate <app_id> /path/to/config
+speechly validate <app_id> .
+speechly validate --app <app_id> /path/to/config
 ```
-
-## Options
-
-```
-  -a, --app string   Application to validate the files for. Can be given as the first positional argument.
-  -h, --help         help for validate
-```
-
-## See also
-
-* [speechly](README.md)	 - Speechly CLI
-

--- a/docs/version.md
+++ b/docs/version.md
@@ -2,17 +2,12 @@
 
 Print the version number
 
+### Usage
+
 ```
 speechly version [flags]
 ```
 
-## Options
+### Flags
 
-```
-  -h, --help   help for version
-```
-
-## See also
-
-* [speechly](README.md)	 - Speechly CLI
-
+* `--help` `-h` _(bool)_ - help for version


### PR DESCRIPTION
The previous version used cobras own `GenMarkdownTreeCustom` functions, but it had it's flaws. Instead of hacking away with regex, i rewrote the generation script to better support the desired output.

While at it, created a new `speechly projects list` subcommand. I found it inconsistent that invoking `projects` listed all the projects while it also had 3 subcommands. With this change it behaves like our other parent commands.

I also updated the long and short texts for many commands, added examples to commands that didn't have any and added some aliases.