### PR TITLE
Don't clear the download directory

### DIFF
--- a/cmd/download.go
+++ b/cmd/download.go
@@ -84,25 +84,6 @@ func downloadCurrentConfiguration(ctx context.Context, d *os.File, absPath strin
 		log.Fatalf("Error connecting to API: %s", err)
 	}
 
-	names, err := d.Readdirnames(-1)
-	if err != nil {
-		log.Fatalf("Reading output directory failed: %s", err)
-	}
-	for _, name := range names {
-		err = os.RemoveAll(filepath.Join(absPath, name))
-		if err != nil {
-			log.Fatalf("Deleting output directory contents failed: %s", err)
-		}
-	}
-	err = d.Close()
-	if err != nil {
-		log.Fatalf("Reading output directory failed: %s", err)
-	}
-
-	if err := os.MkdirAll(absPath, 0755); err != nil {
-		log.Fatalf("Could not create the download directory %s: %s", absPath, err)
-	}
-
 	var buf []byte
 	stream, err := client.DownloadCurrentTrainingData(ctx, &configv1.DownloadCurrentTrainingDataRequest{AppId: appId})
 	if err != nil {

--- a/pkg/upload/tar.go
+++ b/pkg/upload/tar.go
@@ -80,7 +80,7 @@ func ExtractTarToDir(outDir string, r io.Reader) error {
 			}
 		case tar.TypeReg:
 			fmt.Printf("Writing file %s (%d bytes)\n", target, header.Size)
-			f, err := os.OpenFile(target, os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode))
+			f, err := os.OpenFile(target, os.O_RDWR|os.O_CREATE|os.O_TRUNC, os.FileMode(header.Mode))
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2579244/214284061-81d9427f-1f47-42b8-a29c-ceae7f595a47.png)

Previously when invoking the `download` command, it would clear the whole directory and then write the downloaded configuration in that folder. This was a particularly nasty if one wanted to download the `config.yaml` in the current working directory. Personally i think this behaviour is rather dangerous, as the user might accidentally loose any unsaved/committed work.

In this PR the clearing of the download directory is removed. Any files in the download directory with the same filename as in the configuration will be overwritten, though. All other files in the download directory are left as is.